### PR TITLE
Add initial archive support to rundetection

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ docker build . -f ./container/rundetection.D -t ghcr.io/interactivereduction/run
 - Run the container by running:
 
 ```shell
-docker run -it --rm --name rundetection ghcr.io/interactivereduction/rundetection
+docker run -it --rm --mount source=/archive,target=/archive --name rundetection ghcr.io/interactivereduction/rundetection
 ```
 
 - To push containers you will need to setup the correct access for it, you can follow

--- a/rundetection/run_detection.py
+++ b/rundetection/run_detection.py
@@ -4,7 +4,6 @@ Run detection module holds the RunDetector main class
 import logging
 import sys
 import time
-import os
 from pathlib import Path
 from queue import SimpleQueue
 

--- a/rundetection/run_detection.py
+++ b/rundetection/run_detection.py
@@ -4,6 +4,7 @@ Run detection module holds the RunDetector main class
 import logging
 import sys
 import time
+import os
 from queue import SimpleQueue
 
 from rundetection.notifications import Notifier, Notification
@@ -46,11 +47,18 @@ class RunDetector:
         self._queue_listener.acknowledge(message)
 
 
-def main() -> None:
+def main(archive_path="/archive") -> None:
     """
     run-detection entrypoint.
+    :arg archive_path: Added purely for testing purposes, but should also be potentially useful.
     :return: None
     """
+    # Check that the archive can be accessed
+    if os.path.exists(os.path.join(archive_path, "NDXALF")):
+        logger.info("The archive has been mounted correctly, and can be accessed.")
+    else:
+        logger.error("The archive has not been mounted correctly, and cannot be accessed.")
+
     logger.info("Starting run detection")
     run_detector = RunDetector()
     run_detector.run()

--- a/rundetection/run_detection.py
+++ b/rundetection/run_detection.py
@@ -5,6 +5,7 @@ import logging
 import sys
 import time
 import os
+from pathlib import Path
 from queue import SimpleQueue
 
 from rundetection.notifications import Notifier, Notification
@@ -54,7 +55,7 @@ def main(archive_path: str = "/archive") -> None:
     :return: None
     """
     # Check that the archive can be accessed
-    if os.path.exists(os.path.join(archive_path, "NDXALF")):
+    if Path(archive_path, "NDXALF").exists():
         logger.info("The archive has been mounted correctly, and can be accessed.")
     else:
         logger.error("The archive has not been mounted correctly, and cannot be accessed.")

--- a/rundetection/run_detection.py
+++ b/rundetection/run_detection.py
@@ -47,7 +47,7 @@ class RunDetector:
         self._queue_listener.acknowledge(message)
 
 
-def main(archive_path="/archive") -> None:
+def main(archive_path: str = "/archive") -> None:
     """
     run-detection entrypoint.
     :arg archive_path: Added purely for testing purposes, but should also be potentially useful.

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -24,7 +24,8 @@ class MainTest(unittest.TestCase):
         with self.assertLogs('rundetection.run_detection', level='INFO') as info_logs:
             if not os.path.exists(expected_path):
                 # If archive does not exist
-                os.makedirs(expected_path)
+                os.umask(0)
+                os.makedirs(expected_path, mode=0o777)
                 main()
                 os.removedirs(expected_path)
             else:

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -18,11 +18,13 @@ class MainTest(unittest.TestCase):
         """
         Testing that it checks for the archive being present by checking for /archive/ndxalf
         """
+        expected_path = "/archive/ndxalf"
         with self.assertLogs('rundetection.run_detection', level='INFO') as cm:
-            if not os.path.exists("/archive/ndxalf"):
+            if not os.path.exists(expected_path):
                 # If archive does not exist
-                with tempfile.TemporaryDirectory(dir="/archive/ndxalf"):
-                    main()
+                os.makedirs(expected_path)
+                main()
+                os.removedirs(expected_path)
             else:
                 # If archive exists and is mounted on the system
                 main()

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -3,7 +3,6 @@ Tests for run detection module's main function
 """
 import random
 import string
-import tempfile
 import unittest
 import os
 from unittest import mock
@@ -13,13 +12,16 @@ from rundetection.run_detection import main
 
 
 class MainTest(unittest.TestCase):
+    """
+    The main test class
+    """
     @mock.patch("rundetection.run_detection.RunDetector")
     def test_main_finds_archive_if_present(self, _: Mock) -> None:
         """
         Testing that it checks for the archive being present by checking for /archive/ndxalf
         """
         expected_path = "/archive/ndxalf"
-        with self.assertLogs('rundetection.run_detection', level='INFO') as cm:
+        with self.assertLogs('rundetection.run_detection', level='INFO') as info_logs:
             if not os.path.exists(expected_path):
                 # If archive does not exist
                 os.makedirs(expected_path)
@@ -28,15 +30,17 @@ class MainTest(unittest.TestCase):
             else:
                 # If archive exists and is mounted on the system
                 main()
-        self.assertEqual(cm.output, ['INFO:rundetection.run_detection:The archive has been mounted correctly, and can be accessed.',
-                                     'INFO:rundetection.run_detection:Starting run detection'])
+        self.assertEqual(info_logs.output,
+                         ['INFO:rundetection.run_detection:The archive has been mounted correctly, and can be '
+                          'accessed.',
+                          'INFO:rundetection.run_detection:Starting run detection'])
 
     @mock.patch("rundetection.run_detection.RunDetector")
     def test_main_outputs_error_if_archive_not_present(self, _: Mock) -> None:
         """
         Testing that it checks for the archive being present by checking for /archive/ndxalf
         """
-        with self.assertLogs('rundetection.run_detection', level='ERROR') as info_logs:
+        with self.assertLogs('rundetection.run_detection', level='ERROR') as error_logs:
             if os.path.exists("/archive/ndxalf"):
                 # If archive does exist
                 letters = string.ascii_letters
@@ -45,8 +49,9 @@ class MainTest(unittest.TestCase):
             else:
                 # If archive does not exist
                 main()
-        self.assertEqual(info_logs.output, ['ERROR:rundetection.run_detection:The archive has not been mounted correctly, and cannot '
-                                            'be accessed.'])
+        self.assertEqual(error_logs.output,
+                         ['ERROR:rundetection.run_detection:The archive has not been mounted correctly, and cannot '
+                          'be accessed.'])
 
     @mock.patch("rundetection.run_detection.RunDetector")
     def test_main_uses_activemq_env_vars(self, run_detector: Mock) -> None:

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,21 +1,59 @@
 """
 Tests for run detection module's main function
 """
+import random
+import string
+import tempfile
 import unittest
+import os
 from unittest import mock
 from unittest.mock import Mock
 
 from rundetection.run_detection import main
 
 
-@mock.patch("rundetection.run_detection.RunDetector")
-def test_main_uses_activemq_env_vars(run_detector: Mock) -> None:
-    """
-    Testing that run_detector.run receives the correct variables from the environment
-    """
-    main()
+class MainTest(unittest.TestCase):
+    @mock.patch("rundetection.run_detection.RunDetector")
+    def test_main_finds_archive_if_present(self, _: Mock) -> None:
+        """
+        Testing that it checks for the archive being present by checking for /archive/ndxalf
+        """
+        with self.assertLogs('rundetection.run_detection', level='INFO') as cm:
+            if not os.path.exists("/archive/ndxalf"):
+                # If archive does not exist
+                with tempfile.TemporaryDirectory(dir="/archive/ndxalf"):
+                    main()
+            else:
+                # If archive exists and is mounted on the system
+                main()
+        self.assertEqual(cm.output, ['INFO:rundetection.run_detection:The archive has been mounted correctly, and can be accessed.',
+                                     'INFO:rundetection.run_detection:Starting run detection'])
 
-    run_detector.return_value.run.assert_called_once_with()
+    @mock.patch("rundetection.run_detection.RunDetector")
+    def test_main_outputs_error_if_archive_not_present(self, _: Mock) -> None:
+        """
+        Testing that it checks for the archive being present by checking for /archive/ndxalf
+        """
+        with self.assertLogs('rundetection.run_detection', level='ERROR') as info_logs:
+            if os.path.exists("/archive/ndxalf"):
+                # If archive does exist
+                letters = string.ascii_letters
+                result_str = ''.join(random.choice(letters) for _ in range(20))
+                main(f"/tmp/{result_str}")
+            else:
+                # If archive does not exist
+                main()
+        self.assertEqual(info_logs.output, ['ERROR:rundetection.run_detection:The archive has not been mounted correctly, and cannot '
+                                            'be accessed.'])
+
+    @mock.patch("rundetection.run_detection.RunDetector")
+    def test_main_uses_activemq_env_vars(self, run_detector: Mock) -> None:
+        """
+        Testing that run_detector.run receives the correct variables from the environment
+        """
+        main()
+
+        run_detector.return_value.run.assert_called_once_with()
 
 
 if __name__ == '__main__':

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -15,19 +15,26 @@ class MainTest(unittest.TestCase):
     """
     The main test class
     """
+    @staticmethod
+    def generate_string():
+        """
+        Generate a fake directory name that is 20 characters long from upper and lower case characters
+        """
+        return ''.join(random.choice(string.ascii_letters) for _ in range(20))
+
     @mock.patch("rundetection.run_detection.RunDetector")
     def test_main_finds_archive_if_present(self, _: Mock) -> None:
         """
         Testing that it checks for the archive being present by checking for /archive/ndxalf
         """
-        expected_path = "/archive/ndxalf"
+        result_str = self.generate_string()
+        expected_path = f"/tmp/{result_str}"
         with self.assertLogs('rundetection.run_detection', level='INFO') as info_logs:
             if not os.path.exists(expected_path):
                 # If archive does not exist
-                os.umask(0)
-                os.makedirs(expected_path, mode=0o777)
+                os.makedirs(expected_path)
                 main()
-                os.removedirs(expected_path)
+                os.rmdir(expected_path)
             else:
                 # If archive exists and is mounted on the system
                 main()
@@ -44,8 +51,7 @@ class MainTest(unittest.TestCase):
         with self.assertLogs('rundetection.run_detection', level='ERROR') as error_logs:
             if os.path.exists("/archive/ndxalf"):
                 # If archive does exist
-                letters = string.ascii_letters
-                result_str = ''.join(random.choice(letters) for _ in range(20))
+                result_str = self.generate_string()
                 main(f"/tmp/{result_str}")
             else:
                 # If archive does not exist

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -46,7 +46,7 @@ class MainTest(unittest.TestCase):
     @mock.patch("rundetection.run_detection.RunDetector")
     def test_main_outputs_error_if_archive_not_present(self, _: Mock) -> None:
         """
-        Testing that it checks for the archive being present by checking for /archive/ndxalf
+        Testing that it checks for the archive not being present by checking for /archive/ndxalf
         """
         result_str = self.generate_string()
         expected_path = f"/tmp/{result_str}"

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -31,9 +31,9 @@ class MainTest(unittest.TestCase):
         with self.assertLogs('rundetection.run_detection', level='INFO') as info_logs:
             if not Path("/archive/ndxalf").exists():
                 # If archive does not exist
-                with TemporaryDirectory() as td:
-                    Path(td, "NDXALF").mkdir()
-                    main(td)
+                with TemporaryDirectory() as temp_dir:
+                    Path(temp_dir, "NDXALF").mkdir()
+                    main(temp_dir)
 
             else:
                 # If archive exists and is mounted on the system
@@ -68,7 +68,8 @@ class MainTest(unittest.TestCase):
         """
         main()
 
-        run_detector.return_value.run.assert_called_once()
+        run_detector.return_value.run.assert_called_once_with()
+
 
 
 if __name__ == '__main__':

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -4,7 +4,8 @@ Tests for run detection module's main function
 import random
 import string
 import unittest
-import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest import mock
 from unittest.mock import Mock
 
@@ -27,14 +28,13 @@ class MainTest(unittest.TestCase):
         """
         Testing that it checks for the archive being present by checking for /archive/ndxalf
         """
-        result_str = self.generate_string()
-        expected_path = f"/tmp/{result_str}"
         with self.assertLogs('rundetection.run_detection', level='INFO') as info_logs:
-            if not os.path.exists("/archive/ndxalf"):
+            if not Path("/archive/ndxalf").exists():
                 # If archive does not exist
-                os.makedirs(os.path.join(expected_path, "NDXALF"))
-                main(expected_path)
-                os.removedirs(os.path.join(expected_path, "NDXALF"))
+                with TemporaryDirectory() as td:
+                    Path(td, "NDXALF").mkdir()
+                    main(td)
+
             else:
                 # If archive exists and is mounted on the system
                 main()
@@ -51,7 +51,7 @@ class MainTest(unittest.TestCase):
         result_str = self.generate_string()
         expected_path = f"/tmp/{result_str}"
         with self.assertLogs('rundetection.run_detection', level='ERROR') as error_logs:
-            if os.path.exists("/archive/ndxalf"):
+            if Path("/archive/ndxalf").exists():
                 # If archive does exist, use a fake directory
                 main(expected_path)
             else:
@@ -68,7 +68,7 @@ class MainTest(unittest.TestCase):
         """
         main()
 
-        run_detector.return_value.run.assert_called_once_with()
+        run_detector.return_value.run.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -30,11 +30,11 @@ class MainTest(unittest.TestCase):
         result_str = self.generate_string()
         expected_path = f"/tmp/{result_str}"
         with self.assertLogs('rundetection.run_detection', level='INFO') as info_logs:
-            if not os.path.exists(expected_path):
+            if not os.path.exists("/archive/ndxalf"):
                 # If archive does not exist
-                os.makedirs(expected_path)
-                main()
-                os.rmdir(expected_path)
+                os.makedirs(os.path.join(expected_path, "NDXALF"))
+                main(expected_path)
+                os.removedirs(os.path.join(expected_path, "NDXALF"))
             else:
                 # If archive exists and is mounted on the system
                 main()
@@ -48,11 +48,12 @@ class MainTest(unittest.TestCase):
         """
         Testing that it checks for the archive being present by checking for /archive/ndxalf
         """
+        result_str = self.generate_string()
+        expected_path = f"/tmp/{result_str}"
         with self.assertLogs('rundetection.run_detection', level='ERROR') as error_logs:
             if os.path.exists("/archive/ndxalf"):
-                # If archive does exist
-                result_str = self.generate_string()
-                main(f"/tmp/{result_str}")
+                # If archive does exist, use a fake directory
+                main(expected_path)
             else:
                 # If archive does not exist
                 main()


### PR DESCRIPTION
Output an error if an archive connection is not possible, or an info-level log if the connection is successful.

Also added testing for this new capability.

This is the initial step in being able to access the files from rundetection and the rest of the work for actually connecting to the archive in order to use it, will be completed in the https://github.com/interactivereduction/k8s