### PR TITLE
Allow queue from env

### DIFF
--- a/rundetection/queue_listener.py
+++ b/rundetection/queue_listener.py
@@ -36,6 +36,7 @@ class QueueListener(ConnectionListener):  # type: ignore # No Library stub
         self._ip: str = os.environ.get("ACTIVEMQ_IP", "localhost")
         self._user: str = os.environ.get("ACTIVEMQ_USER", "admin")
         self._password: str = os.environ.get("ACTIVEMQ_PASS", "admin")
+        self._queue: str = os.environ.get("ACTIVEMQ_QUEUE", "Interactive-Reduction")
         self._connection: Connection = Connection([(self._ip, 61613)])
         self._subscription_id = "1"
         super().__init__()
@@ -63,7 +64,7 @@ class QueueListener(ConnectionListener):  # type: ignore # No Library stub
             self._connection.connect(username=self._user, password=self._password)
             self._connection.set_listener(listener=self, name="run-detection-listener")
             self._connection.subscribe(
-                destination="Interactive-Reduction",
+                destination=self._queue,
                 id=self._subscription_id,
                 ack="client",
             )

--- a/test/test_queue_listener.py
+++ b/test/test_queue_listener.py
@@ -161,5 +161,25 @@ def assert_connect_and_subscribe(listener: QueueListener, username: str = "admin
     )
 
 
+def test_connect_and_subscribe_with_queue_var() -> None:
+    """
+    Assert the given queue listener attempted to connect
+    :return: None
+    """
+    os.environ["ACTIVEMQ_QUEUE"] = "fancy_queue"
+    message_queue: SimpleQueue[Message] = SimpleQueue()
+    listener = QueueListener(message_queue)
+
+    listener._connection = Mock()
+    listener.run()
+
+    listener._connection.connect.assert_called_once_with(username="admin", password="admin")
+    listener._connection.set_listener.assert_called_once_with(listener=listener, name="run-detection-listener")
+    listener._connection.subscribe.assert_called_once_with(
+        destination="fancy_queue", id=listener._subscription_id, ack="client"
+    )
+    os.environ.pop("ACTIVEMQ_QUEUE", None)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_queue_listener.py
+++ b/test/test_queue_listener.py
@@ -148,6 +148,9 @@ def test_connection_username_and_password_can_be_set_by_environment_variable() -
     listener.run()
     assert_connect_and_subscribe(listener, username="great_username", password="great_password")
 
+    os.environ.pop("ACTIVEMQ_USER", None)
+    os.environ.pop("ACTIVEMQ_PASS", None)
+
 
 def assert_connect_and_subscribe(listener: QueueListener, username: str = "admin", password: str = "admin") -> None:
     """


### PR DESCRIPTION
Closes None

## Description
Fixes bug in prod, where queue name is defined incorrectly in code, so now we can set it on an env var
