### PR TITLE
Upgrade queue listener

### DIFF
--- a/rundetection/queue_listener.py
+++ b/rundetection/queue_listener.py
@@ -58,10 +58,16 @@ class QueueListener(ConnectionListener):  # type: ignore # No Library stub
         logger.warning("Disconnected, attempting reconnect...")
         self._connect_and_subscribe()
 
+    def on_error(self, frame: Frame) -> None:
+        """
+        Called on error from message broker.
+        """
+        logger.warning("Error recieved from message broker: %s", frame.body)
+
     def _connect_and_subscribe(self) -> None:
         try:
             logger.info("Attempting connection")
-            self._connection.connect(username=self._user, password=self._password)
+            self._connection.connect(username=self._user, passcode=self._password)
             self._connection.set_listener(listener=self, name="run-detection-listener")
             self._connection.subscribe(
                 destination=self._queue,

--- a/rundetection/queue_listener.py
+++ b/rundetection/queue_listener.py
@@ -3,6 +3,7 @@ broker """
 import logging
 import os
 import time
+import uuid
 from dataclasses import dataclass
 from queue import SimpleQueue
 
@@ -38,7 +39,7 @@ class QueueListener(ConnectionListener):  # type: ignore # No Library stub
         self._password: str = os.environ.get("ACTIVEMQ_PASS", "admin")
         self._queue: str = os.environ.get("ACTIVEMQ_QUEUE", "Interactive-Reduction")
         self._connection: Connection = Connection([(self._ip, 61613)])
-        self._subscription_id = "1"
+        self._subscription_id = str(uuid.uuid4())
         super().__init__()
 
     def on_message(self, frame: Frame) -> None:

--- a/test/test_queue_listener.py
+++ b/test/test_queue_listener.py
@@ -157,7 +157,7 @@ def assert_connect_and_subscribe(listener: QueueListener, username: str = "admin
     Assert the given queue listener attempted to connect
     :return: None
     """
-    listener._connection.connect.assert_called_once_with(username=username, password=password)
+    listener._connection.connect.assert_called_once_with(username=username, passcode=password)
     listener._connection.set_listener.assert_called_once_with(listener=listener, name="run-detection-listener")
     listener._connection.subscribe.assert_called_once_with(
         destination="Interactive-Reduction", id=listener._subscription_id, ack="client"
@@ -176,7 +176,7 @@ def test_connect_and_subscribe_with_queue_var() -> None:
     listener._connection = Mock()
     listener.run()
 
-    listener._connection.connect.assert_called_once_with(username="admin", password="admin")
+    listener._connection.connect.assert_called_once_with(username="admin", passcode="admin")
     listener._connection.set_listener.assert_called_once_with(listener=listener, name="run-detection-listener")
     listener._connection.subscribe.assert_called_once_with(
         destination="fancy_queue", id=listener._subscription_id, ack="client"


### PR DESCRIPTION
Closes None

## Description
Use UUID for subbing to ActiveMQ, use passcode not password for stomp, and add on_error to queuelistener for logging errors.