### PR TITLE
Cache journals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ dependencies = [
     "pika==1.3.2",
     "h5py==3.14.0",
     "xmltodict==0.15.1",
-    "requests==2.32.5"
+    "requests==2.32.5",
+    "valkey==6.1.1"
 ]
 
 

--- a/rundetection/cache.py
+++ b/rundetection/cache.py
@@ -80,7 +80,7 @@ def cache_get_json(key: str) -> Any | None:
         return None
     if raw is None:
         return None
-    if isinstance(raw, (bytes, bytearray)):
+    if isinstance(raw, bytes | bytearray):
         raw_text = raw.decode("utf-8")
     elif isinstance(raw, str):
         raw_text = raw

--- a/rundetection/cache.py
+++ b/rundetection/cache.py
@@ -1,0 +1,110 @@
+"""Valkey cache helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from functools import cache
+from typing import Any
+
+from valkey import Valkey
+from valkey.exceptions import ValkeyError
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_VALKEY_URL = "redis://valkey.valkey.svc.cluster.local:6379/0"
+
+
+@dataclass(slots=True)
+class _ValkeyState:
+    client: Valkey | None = None
+    disabled: bool = False
+
+
+@cache
+def _valkey_state() -> _ValkeyState:
+    return _ValkeyState()
+
+
+def _create_client() -> Valkey:
+    url = os.environ.get("VALKEY_URL", DEFAULT_VALKEY_URL)
+    return Valkey.from_url(
+        url,
+        decode_responses=True,
+        socket_connect_timeout=0.5,
+        socket_timeout=1,
+        retry_on_timeout=False,
+    )
+
+
+def get_valkey_client() -> Valkey | None:
+    """
+    Get or create a shared Valkey client.
+
+    The client is created lazily. If Valkey is unavailable, future calls return
+    None without repeatedly attempting a connection.
+    """
+    state = _valkey_state()
+    if state.disabled:
+        logger.warning("Valkey cache disabled: previous connection error")
+        return None
+    if state.client is None:
+        try:
+            state.client = _create_client()
+        except (ValkeyError, ValueError) as exc:
+            state.disabled = True
+            logger.warning("Valkey cache disabled: %s", exc)
+            return None
+    return state.client
+
+
+def _disable_cache(exc: Exception) -> None:
+    state = _valkey_state()
+    if not state.disabled:
+        state.disabled = True
+        logger.warning("Valkey cache disabled: %s", exc)
+
+
+def cache_get_json(key: str) -> Any | None:
+    """Retrieve and deserialize a JSON value from Valkey."""
+    client = get_valkey_client()
+    if client is None:
+        return None
+    try:
+        raw = client.get(key)
+    except ValkeyError as exc:
+        _disable_cache(exc)
+        logger.exception("Failed to retrieve JSON from Valkey cache", exc_info=exc)
+        return None
+    if raw is None:
+        return None
+    if isinstance(raw, (bytes, bytearray)):
+        raw_text = raw.decode("utf-8")
+    elif isinstance(raw, str):
+        raw_text = raw
+    else:
+        return None
+    try:
+        return json.loads(raw_text)
+    except json.JSONDecodeError:
+        logger.warning("Failed to parse JSON from Valkey cache for key: %s", key)
+        return None
+
+
+def cache_set_json(key: str, value: Any, ttl_seconds: int) -> None:
+    """Store a JSON-serializable value in Valkey with a time-to-live."""
+    if ttl_seconds <= 0:
+        return
+    client = get_valkey_client()
+    if client is None:
+        return
+    try:
+        payload = json.dumps(value)
+    except TypeError:
+        return
+    try:
+        client.setex(key, ttl_seconds, payload)
+    except ValkeyError as exc:
+        _disable_cache(exc)

--- a/rundetection/cache.py
+++ b/rundetection/cache.py
@@ -8,7 +8,7 @@ import logging
 import os
 from dataclasses import dataclass
 from functools import cache
-from typing import Any, Protocol, cast
+from typing import Any
 
 from valkey import Valkey
 from valkey.exceptions import ValkeyError
@@ -22,10 +22,6 @@ DEFAULT_VALKEY_URL = "redis://valkey.valkey.svc.cluster.local:6379/0"
 class _ValkeyState:
     client: Valkey | None = None
     disabled: bool = False
-
-
-class _Closable(Protocol):
-    def close(self) -> None: ...
 
 
 @cache
@@ -72,7 +68,7 @@ def _disable_cache(exc: Exception) -> None:
         state.client = None
         if client is not None:
             with contextlib.suppress(Exception):
-                cast("_Closable", client).close()
+                client.close()
         logger.warning("Valkey cache disabled: %s", exc)
 
 

--- a/rundetection/cache.py
+++ b/rundetection/cache.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -40,15 +41,13 @@ def _create_client() -> Valkey:
 
 
 def get_valkey_client() -> Valkey | None:
-    """
-    Get or create a shared Valkey client.
+    """Get or create a shared Valkey client.
 
-    The client is created lazily. If Valkey is unavailable, future calls return
-    None without repeatedly attempting a connection.
+    The client is created lazily. If Valkey is unavailable, future calls
+    return None without repeatedly attempting a connection.
     """
     state = _valkey_state()
     if state.disabled:
-        logger.warning("Valkey cache disabled: previous connection error")
         return None
     if state.client is None:
         try:
@@ -64,6 +63,11 @@ def _disable_cache(exc: Exception) -> None:
     state = _valkey_state()
     if not state.disabled:
         state.disabled = True
+        client = state.client
+        state.client = None
+        if client is not None:
+            with contextlib.suppress(Exception):
+                client.close()
         logger.warning("Valkey cache disabled: %s", exc)
 
 
@@ -76,7 +80,7 @@ def cache_get_json(key: str) -> Any | None:
         raw = client.get(key)
     except ValkeyError as exc:
         _disable_cache(exc)
-        logger.exception("Failed to retrieve JSON from Valkey cache", exc_info=exc)
+        logger.exception("Failed to retrieve JSON from Valkey cache for key: %s", key)
         return None
     if raw is None:
         return None
@@ -108,3 +112,4 @@ def cache_set_json(key: str, value: Any, ttl_seconds: int) -> None:
         client.setex(key, ttl_seconds, payload)
     except ValkeyError as exc:
         _disable_cache(exc)
+        logger.exception("Failed to store JSON in Valkey cache for key: %s", key)

--- a/rundetection/cache.py
+++ b/rundetection/cache.py
@@ -41,7 +41,8 @@ def _create_client() -> Valkey:
 
 
 def get_valkey_client() -> Valkey | None:
-    """Get or create a shared Valkey client.
+    """
+    Get or create a shared Valkey client.
 
     The client is created lazily. If Valkey is unavailable, future calls
     return None without repeatedly attempting a connection.

--- a/rundetection/cache.py
+++ b/rundetection/cache.py
@@ -71,7 +71,7 @@ def _disable_cache(exc: Exception) -> None:
         state.client = None
         if client is not None:
             with contextlib.suppress(Exception):
-                cast(_Closable, client).close()
+                cast("_Closable", client).close()
         logger.warning("Valkey cache disabled: %s", exc)
 
 

--- a/rundetection/cache.py
+++ b/rundetection/cache.py
@@ -16,6 +16,8 @@ from valkey.exceptions import ValkeyError
 logger = logging.getLogger(__name__)
 
 DEFAULT_VALKEY_URL = "redis://valkey.valkey.svc.cluster.local:6379/0"
+VALKEY_CACHE_ENABLED_ENV_VAR = "VALKEY_CACHE_ENABLED"
+DISABLED_ENV_VALUES = {"0", "false", "no", "off"}
 
 
 @dataclass(slots=True)
@@ -27,6 +29,13 @@ class _ValkeyState:
 @cache
 def _valkey_state() -> _ValkeyState:
     return _ValkeyState()
+
+
+def _valkey_cache_enabled() -> bool:
+    configured_value = os.environ.get(VALKEY_CACHE_ENABLED_ENV_VAR)
+    if configured_value is None:
+        return True
+    return configured_value.strip().lower() not in DISABLED_ENV_VALUES
 
 
 def _create_client() -> Valkey:
@@ -44,9 +53,12 @@ def get_valkey_client() -> Valkey | None:
     """
     Get or create a shared Valkey client.
 
-    The client is created lazily. If Valkey is unavailable, future calls
-    return None without repeatedly attempting a connection.
+    The client is created lazily. Set VALKEY_CACHE_ENABLED=false to opt
+    out of Valkey caching explicitly.
     """
+    if not _valkey_cache_enabled():
+        return None
+
     state = _valkey_state()
     if state.disabled:
         return None
@@ -54,22 +66,20 @@ def get_valkey_client() -> Valkey | None:
         try:
             state.client = _create_client()
         except (ValkeyError, ValueError) as exc:
-            state.disabled = True
-            logger.warning("Valkey cache disabled: %s", exc)
+            _disable_valkey_cache(exc)
             return None
     return state.client
 
 
-def _disable_cache(exc: Exception) -> None:
+def _disable_valkey_cache(exc: Exception) -> None:
     state = _valkey_state()
-    if not state.disabled:
-        state.disabled = True
-        client = state.client
-        state.client = None
-        if client is not None:
-            with contextlib.suppress(Exception):
-                client.close()
-        logger.warning("Valkey cache disabled: %s", exc)
+    state.disabled = True
+    client = state.client
+    state.client = None
+    if client is not None:
+        with contextlib.suppress(Exception):
+            client.close()
+    logger.warning("Valkey cache disabled: %s", exc)
 
 
 def cache_get_json(key: str) -> Any | None:
@@ -80,8 +90,8 @@ def cache_get_json(key: str) -> Any | None:
     try:
         raw = client.get(key)
     except ValkeyError as exc:
-        _disable_cache(exc)
-        logger.exception("Failed to retrieve JSON from Valkey cache for key: %s", key)
+        _disable_valkey_cache(exc)
+        logger.warning("Failed to retrieve JSON from Valkey cache for key %s: %s", key, exc)
         return None
     if raw is None:
         return None
@@ -107,10 +117,11 @@ def cache_set_json(key: str, value: Any, ttl_seconds: int) -> None:
         return
     try:
         payload = json.dumps(value)
-    except TypeError:
+    except TypeError as exc:
+        logger.warning("Failed to serialize JSON for Valkey cache key %s: %s", key, exc)
         return
     try:
         client.setex(key, ttl_seconds, payload)
     except ValkeyError as exc:
-        _disable_cache(exc)
-        logger.exception("Failed to store JSON in Valkey cache for key: %s", key)
+        _disable_valkey_cache(exc)
+        logger.warning("Failed to store JSON in Valkey cache for key %s: %s", key, exc)

--- a/rundetection/cache.py
+++ b/rundetection/cache.py
@@ -45,7 +45,8 @@ def _create_client() -> Valkey:
 
 
 def get_valkey_client() -> Valkey | None:
-    """Get or create a shared Valkey client.
+    """
+    Get or create a shared Valkey client.
 
     The client is created lazily. If Valkey is unavailable, future calls
     return None without repeatedly attempting a connection.
@@ -71,7 +72,7 @@ def _disable_cache(exc: Exception) -> None:
         state.client = None
         if client is not None:
             with contextlib.suppress(Exception):
-                cast(_Closable, client).close()
+                cast("_Closable", client).close()
         logger.warning("Valkey cache disabled: %s", exc)
 
 

--- a/rundetection/cache.py
+++ b/rundetection/cache.py
@@ -8,7 +8,7 @@ import logging
 import os
 from dataclasses import dataclass
 from functools import cache
-from typing import Any
+from typing import Any, Protocol, cast
 
 from valkey import Valkey
 from valkey.exceptions import ValkeyError
@@ -22,6 +22,10 @@ DEFAULT_VALKEY_URL = "redis://valkey.valkey.svc.cluster.local:6379/0"
 class _ValkeyState:
     client: Valkey | None = None
     disabled: bool = False
+
+
+class _Closable(Protocol):
+    def close(self) -> None: ...
 
 
 @cache
@@ -41,8 +45,7 @@ def _create_client() -> Valkey:
 
 
 def get_valkey_client() -> Valkey | None:
-    """
-    Get or create a shared Valkey client.
+    """Get or create a shared Valkey client.
 
     The client is created lazily. If Valkey is unavailable, future calls
     return None without repeatedly attempting a connection.
@@ -68,7 +71,7 @@ def _disable_cache(exc: Exception) -> None:
         state.client = None
         if client is not None:
             with contextlib.suppress(Exception):
-                client.close()
+                cast(_Closable, client).close()
         logger.warning("Valkey cache disabled: %s", exc)
 
 

--- a/rundetection/rules/enginx_rules.py
+++ b/rundetection/rules/enginx_rules.py
@@ -6,12 +6,12 @@ import contextlib
 import logging
 import os
 import re
-from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Self
 
 import xmltodict
 
+from rundetection.cache import cache_get_json, cache_set_json
 from rundetection.exceptions import RuleViolationError
 from rundetection.rules.rule import Rule
 
@@ -19,6 +19,9 @@ if TYPE_CHECKING:
     from rundetection.job_requests import JobRequest
 
 logger = logging.getLogger(__name__)
+
+ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY = "run_detection:enginx:run_number_cycle_map"
+ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_TTL_SECONDS = 60 * 60
 
 
 class EnginxGroupRule(Rule[str]):
@@ -129,21 +132,49 @@ class EnginxVanadiumPathRule(EnginxBasePathRule):
     path_key: str = "vanadium_path"
 
 
-@lru_cache(maxsize=1)
-def build_enginx_run_number_cycle_map() -> dict[int, str]:
-    """
-    Generate a mapping of run numbers to cycle strings based on the journal files.
-    For example. mapping[242666] -> "15_1"
-    :return: A dict[int, str] mapping run numbers to cycle strings.
-    """
+def _enginx_journal_dir() -> Path:
+    configured_path = os.environ.get("ENGINX_JOURNAL_DIR")
+    if configured_path:
+        return Path(configured_path)
+    return Path(os.environ.get("ARCHIVE_ROOT", "/archive")) / "NDXENGINX" / "Instrument" / "logs" / "journal"
+
+
+def _enginx_run_number_cycle_map_cache_ttl_seconds() -> int:
+    configured_ttl = os.environ.get("ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_TTL_SECONDS")
+    if configured_ttl is None:
+        return ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_TTL_SECONDS
+    try:
+        return int(configured_ttl)
+    except ValueError:
+        logger.warning("Invalid ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_TTL_SECONDS value: %s", configured_ttl)
+        return ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_TTL_SECONDS
+
+
+def _coerce_run_number_cycle_map(value: Any) -> dict[int, str] | None:
+    if not isinstance(value, dict):
+        return None
+
+    mapping: dict[int, str] = {}
+    for run_number, cycle in value.items():
+        if not isinstance(cycle, str):
+            return None
+        try:
+            mapping[int(run_number)] = cycle
+        except (TypeError, ValueError):
+            return None
+    return mapping
+
+
+def _read_enginx_run_number_cycle_map(journal_dir: Path) -> dict[int, str]:
     logger.info("Building run number cycle map")
-    mapping = {}
+    mapping: dict[int, str] = {}
 
     def _walk_node(node: list[Any] | dict[str, Any], journal_file: str) -> None:
         if isinstance(node, dict):
-            if "@name" in node:
+            entry_name = node.get("@name")
+            if isinstance(entry_name, str) and entry_name.upper().startswith("ENGINX"):
                 with contextlib.suppress(ValueError):
-                    mapping[int(node["@name"][6:])] = journal_file[8:]
+                    mapping[int(entry_name[6:])] = journal_file.removeprefix("journal_")
                 return
             for v in node.values():
                 _walk_node(v, journal_file)
@@ -151,11 +182,30 @@ def build_enginx_run_number_cycle_map() -> dict[int, str]:
             for item in node:
                 _walk_node(item, journal_file)
 
-    logger.info("Reading journal files...")
-    for path in Path("/archive/NDXENGINX/Instrument/logs/journal").glob("*.xml"):
+    logger.info("Reading journal files from %s", journal_dir)
+    for path in journal_dir.glob("*.xml"):
         logger.info("Reading journal file: %s", path)
         with path.open() as journal:
             journal_dict = xmltodict.parse(journal.read())
             _walk_node(journal_dict, path.stem)
     logger.info("Mapping complete")
+    return mapping
+
+
+def build_enginx_run_number_cycle_map() -> dict[int, str]:
+    """
+    Generate a mapping of run numbers to cycle strings based on the journal files.
+    For example. mapping[242666] -> "15_1"
+    :return: A dict[int, str] mapping run numbers to cycle strings.
+    """
+    ttl_seconds = _enginx_run_number_cycle_map_cache_ttl_seconds()
+    if ttl_seconds > 0:
+        cached_mapping = _coerce_run_number_cycle_map(cache_get_json(ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY))
+        if cached_mapping is not None:
+            logger.info("Using cached EnginX run number cycle map")
+            return cached_mapping
+
+    mapping = _read_enginx_run_number_cycle_map(_enginx_journal_dir())
+    if ttl_seconds > 0:
+        cache_set_json(ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY, mapping, ttl_seconds)
     return mapping

--- a/rundetection/rules/enginx_rules.py
+++ b/rundetection/rules/enginx_rules.py
@@ -40,7 +40,8 @@ class EnginxGroupRule(Rule[str]):
     """Insert the group type into the JobRequest."""
 
     def verify(self, job_request: JobRequest) -> None:
-        """Verify the rule against the job request.
+        """
+        Verify the rule against the job request.
 
         Adds the group type to the additional values after validating it
         against a list of valid group types.
@@ -68,7 +69,8 @@ class EnginxBasePathRule(Rule[int | str]):
     path_key: str = "x_path"  # example: "x_path", would be ceria_path, etc.
 
     def verify(self, job_request: JobRequest) -> None:
-        """Find the given ceria or vanadium file path and attach it to the job
+        """
+        Find the given ceria or vanadium file path and attach it to the job
         request.
 
         :param job_request: The job request to add to
@@ -94,13 +96,15 @@ class EnginxBasePathRule(Rule[int | str]):
 
     @classmethod
     def _find_path(cls, run: str) -> Path | None:
-        """Find a file ending with '0*{run}.nxs' (case-insensitive), where the
+        """
+        Find a file ending with '0*{run}.nxs' (case-insensitive), where the
         digit sequence is not preceded by another digit.
 
         Examples:
         ENGINX1234.nxs       ✓
         ENGINX0001234.nxs    ✓
         foo991234.nxs        ✗ (blocked by non-digit boundary)
+
         """
         # non-digit boundary, then any number of '0', then the run, then .nxs at end
         file_re = re.compile(rf"(?i)(?<!\d)0*{re.escape(run)}\.nxs$")
@@ -142,8 +146,10 @@ class EnginxCeriaPathRule(EnginxBasePathRule):
 
 
 class EnginxVanadiumPathRule(EnginxBasePathRule):
-    """Resolve and attach the Vanadium calibration file path for an EnginX
-    run."""
+    """
+    Resolve and attach the Vanadium calibration file path for an EnginX
+    run.
+    """
 
     path_key: str = "vanadium_path"
 
@@ -239,8 +245,10 @@ def _read_enginx_run_number_cycle_map(journal_dir: Path) -> dict[int, str]:
 
 
 def _cached_enginx_run_number_cycle_map(journal_dir: Path, ttl_seconds: int) -> tuple[tuple[int, str], ...]:
-    """Return a TTL-limited run/cycle mapping read from EnginX journal
-    files."""
+    """
+    Return a TTL-limited run/cycle mapping read from EnginX journal
+    files.
+    """
     now = time.monotonic()
     cached = _ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE.get(journal_dir)
     if cached is not None and cached.expires_at > now:
@@ -264,7 +272,8 @@ def _clear_enginx_run_number_cycle_map_cache() -> None:
 
 
 def build_enginx_run_number_cycle_map() -> dict[int, str]:
-    """Generate a mapping of run numbers to cycle strings based on the journal
+    """
+    Generate a mapping of run numbers to cycle strings based on the journal
     files.
 
     For example. mapping[242666] -> "15_1"

--- a/rundetection/rules/enginx_rules.py
+++ b/rundetection/rules/enginx_rules.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY = "run_detection:enginx:run_number_cycle_map"
 ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_TTL_SECONDS = 60 * 60
+_ENGINX_RUN_NAME_PREFIX = "ENGINX"
 _ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE: dict[Path, tuple[tuple[int, str], ...]] = {}
 
 
@@ -170,41 +171,57 @@ def _coerce_run_number_cycle_map(value: Any) -> dict[int, str] | None:
     return mapping
 
 
-def _read_enginx_run_number_cycle_map(journal_dir: Path) -> dict[int, str]:
-    logger.info("Building run number cycle map")
-    mapping: dict[int, str] = {}
+def _add_enginx_run_to_cycle_map(mapping: dict[int, str], entry_name: Any, journal_file: str) -> bool:
+    if not isinstance(entry_name, str):
+        return False
+    if not entry_name.upper().startswith(_ENGINX_RUN_NAME_PREFIX):
+        return False
 
-    def _walk_node(node: list[Any] | dict[str, Any], journal_file: str) -> None:
-        if isinstance(node, dict):
-            entry_name = node.get("@name")
-            if isinstance(entry_name, str) and entry_name.upper().startswith("ENGINX"):
-                with contextlib.suppress(ValueError):
-                    mapping[int(entry_name[6:])] = journal_file.removeprefix("journal_")
-                return
-            for v in node.values():
-                _walk_node(v, journal_file)
-        elif isinstance(node, list):
-            for item in node:
-                _walk_node(item, journal_file)
+    with contextlib.suppress(ValueError):
+        mapping[int(entry_name[len(_ENGINX_RUN_NAME_PREFIX) :])] = journal_file.removeprefix("journal_")
+    return True
 
+
+def _walk_enginx_journal_node(node: Any, journal_file: str, mapping: dict[int, str]) -> None:
+    if isinstance(node, dict):
+        if _add_enginx_run_to_cycle_map(mapping, node.get("@name"), journal_file):
+            return
+        for value in node.values():
+            _walk_enginx_journal_node(value, journal_file, mapping)
+    elif isinstance(node, list):
+        for item in node:
+            _walk_enginx_journal_node(item, journal_file, mapping)
+
+
+def _enginx_journal_files(journal_dir: Path) -> list[Path] | None:
     logger.info("Reading journal files from %s", journal_dir)
     if not journal_dir.exists():
         logger.warning("EnginX journal directory does not exist: %s", journal_dir)
-        return mapping
+        return None
     if not journal_dir.is_dir():
         logger.warning("EnginX journal path is not a directory: %s", journal_dir)
-        return mapping
+        return None
 
     journal_files = list(journal_dir.glob("*.xml"))
     if not journal_files:
         logger.warning("No EnginX journal XML files found in %s", journal_dir)
+        return None
+    return journal_files
+
+
+def _read_enginx_run_number_cycle_map(journal_dir: Path) -> dict[int, str]:
+    logger.info("Building run number cycle map")
+    mapping: dict[int, str] = {}
+
+    journal_files = _enginx_journal_files(journal_dir)
+    if journal_files is None:
         return mapping
 
     for path in journal_files:
         logger.info("Reading journal file: %s", path)
         with path.open() as journal:
             journal_dict = xmltodict.parse(journal.read())
-            _walk_node(journal_dict, path.stem)
+            _walk_enginx_journal_node(journal_dict, path.stem, mapping)
     if not mapping:
         logger.warning("No EnginX runs found in journal XML files from %s", journal_dir)
     logger.info("Mapping complete")

--- a/rundetection/rules/enginx_rules.py
+++ b/rundetection/rules/enginx_rules.py
@@ -22,19 +22,21 @@ logger = logging.getLogger(__name__)
 
 ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY = "run_detection:enginx:run_number_cycle_map"
 ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_TTL_SECONDS = 60 * 60
+_ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE: dict[Path, tuple[tuple[int, str], ...]] = {}
 
 
 class EnginxGroupRule(Rule[str]):
-    """Insert the group type into the JobRequest"""
+    """Insert the group type into the JobRequest."""
 
     def verify(self, job_request: JobRequest) -> None:
-        """
-        Verify the rule against the job request.
+        """Verify the rule against the job request.
 
-        Adds the group type to the additional values after validating it against a list of valid group types.
+        Adds the group type to the additional values after validating it
+        against a list of valid group types.
 
         :param job_request: The job request to verify.
-        :raises RuleViolationError: If the group type is not in the list of valid groups.
+        :raises RuleViolationError: If the group type is not in the list
+            of valid groups.
         :return: None.
         """
         group = self._value
@@ -48,15 +50,16 @@ class EnginxGroupRule(Rule[str]):
 
 
 class EnginxBasePathRule(Rule[int | str]):
-    """Base rule for resolving nexus file paths in the archive"""
+    """Base rule for resolving nexus file paths in the archive."""
 
     _ROOT = Path("/archive/NDXENGINX/Instrument/data")
     _DIR_GLOB = "cycle_"
     path_key: str = "x_path"  # example: "x_path", would be ceria_path, etc.
 
     def verify(self, job_request: JobRequest) -> None:
-        """
-        Find the given ceria or vanadium file path and attach it to the job request.
+        """Find the given ceria or vanadium file path and attach it to the job
+        request.
+
         :param job_request: The job request to add to
         :return: None
         """
@@ -80,12 +83,13 @@ class EnginxBasePathRule(Rule[int | str]):
 
     @classmethod
     def _find_path(cls, run: str) -> Path | None:
-        """
-        Find a file ending with '0*{run}.nxs' (case-insensitive), where the digit
-        sequence is not preceded by another digit. Examples:
-          ENGINX1234.nxs       ✓
-          ENGINX0001234.nxs    ✓
-          foo991234.nxs        ✗ (blocked by non-digit boundary)
+        """Find a file ending with '0*{run}.nxs' (case-insensitive), where the
+        digit sequence is not preceded by another digit.
+
+        Examples:
+        ENGINX1234.nxs       ✓
+        ENGINX0001234.nxs    ✓
+        foo991234.nxs        ✗ (blocked by non-digit boundary)
         """
         # non-digit boundary, then any number of '0', then the run, then .nxs at end
         file_re = re.compile(rf"(?i)(?<!\d)0*{re.escape(run)}\.nxs$")
@@ -127,7 +131,8 @@ class EnginxCeriaPathRule(EnginxBasePathRule):
 
 
 class EnginxVanadiumPathRule(EnginxBasePathRule):
-    """Resolve and attach the Vanadium calibration file path for an EnginX run."""
+    """Resolve and attach the Vanadium calibration file path for an EnginX
+    run."""
 
     path_key: str = "vanadium_path"
 
@@ -183,29 +188,59 @@ def _read_enginx_run_number_cycle_map(journal_dir: Path) -> dict[int, str]:
                 _walk_node(item, journal_file)
 
     logger.info("Reading journal files from %s", journal_dir)
-    for path in journal_dir.glob("*.xml"):
+    if not journal_dir.exists():
+        logger.warning("EnginX journal directory does not exist: %s", journal_dir)
+        return mapping
+    if not journal_dir.is_dir():
+        logger.warning("EnginX journal path is not a directory: %s", journal_dir)
+        return mapping
+
+    journal_files = list(journal_dir.glob("*.xml"))
+    if not journal_files:
+        logger.warning("No EnginX journal XML files found in %s", journal_dir)
+        return mapping
+
+    for path in journal_files:
         logger.info("Reading journal file: %s", path)
         with path.open() as journal:
             journal_dict = xmltodict.parse(journal.read())
             _walk_node(journal_dict, path.stem)
+    if not mapping:
+        logger.warning("No EnginX runs found in journal XML files from %s", journal_dir)
     logger.info("Mapping complete")
     return mapping
 
 
+def _cached_enginx_run_number_cycle_map(journal_dir: Path) -> tuple[tuple[int, str], ...]:
+    """Return a memoized run/cycle mapping read from EnginX journal files."""
+    if journal_dir not in _ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE:
+        mapping = _read_enginx_run_number_cycle_map(journal_dir)
+        if mapping:
+            _ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE[journal_dir] = tuple(mapping.items())
+        return tuple(mapping.items())
+    return _ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE[journal_dir]
+
+
+def _clear_enginx_run_number_cycle_map_cache() -> None:
+    """Clear the memoized EnginX journal mapping."""
+    _ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE.clear()
+
+
 def build_enginx_run_number_cycle_map() -> dict[int, str]:
-    """
-    Generate a mapping of run numbers to cycle strings based on the journal files.
+    """Generate a mapping of run numbers to cycle strings based on the journal
+    files.
+
     For example. mapping[242666] -> "15_1"
     :return: A dict[int, str] mapping run numbers to cycle strings.
     """
     ttl_seconds = _enginx_run_number_cycle_map_cache_ttl_seconds()
     if ttl_seconds > 0:
         cached_mapping = _coerce_run_number_cycle_map(cache_get_json(ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY))
-        if cached_mapping is not None:
+        if cached_mapping:
             logger.info("Using cached EnginX run number cycle map")
             return cached_mapping
 
-    mapping = _read_enginx_run_number_cycle_map(_enginx_journal_dir())
-    if ttl_seconds > 0:
+    mapping = dict(_cached_enginx_run_number_cycle_map(_enginx_journal_dir()))
+    if ttl_seconds > 0 and mapping:
         cache_set_json(ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY, mapping, ttl_seconds)
     return mapping

--- a/rundetection/rules/enginx_rules.py
+++ b/rundetection/rules/enginx_rules.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import contextlib
 import logging
 import os
 import re
@@ -29,6 +28,8 @@ ENGINX_PREFIX = "ENGINX"
 
 @dataclass(slots=True)
 class EnginxCacheEntry:
+    """In-process EnginX journal cache entry."""
+
     items: tuple[tuple[int, str], ...]
     expires_at: float
 
@@ -183,8 +184,11 @@ def _add_enginx_run_to_cycle_map(mapping: dict[int, str], entry_name: Any, journ
     if not entry_name.upper().startswith(ENGINX_PREFIX):
         return False
 
-    with contextlib.suppress(ValueError):
-        mapping[int(entry_name[len(ENGINX_PREFIX) :])] = journal_file.removeprefix("journal_")
+    try:
+        run_number = int(entry_name[len(ENGINX_PREFIX) :])
+    except ValueError:
+        return False
+    mapping[run_number] = journal_file.removeprefix("journal_")
     return True
 
 
@@ -234,26 +238,28 @@ def _read_enginx_run_number_cycle_map(journal_dir: Path) -> dict[int, str]:
     return mapping
 
 
-def _cached_enginx_run_number_cycle_map(journal_dir: Path, ttl_seconds: int) -> tuple[tuple[int, str], ...]:
-    """
-    Return a TTL-limited run/cycle mapping read from EnginX journal
-    files.
-    """
-    now = time.monotonic()
+def _get_cached_enginx_run_number_cycle_map(journal_dir: Path, now: float) -> dict[int, str] | None:
     cached = ENGINX_CACHE.get(journal_dir)
     if cached is not None and cached.expires_at > now:
-        return cached.items
+        return dict(cached.items)
+    if cached is not None:
+        ENGINX_CACHE.pop(journal_dir, None)
+    return None
 
-    mapping = _read_enginx_run_number_cycle_map(journal_dir)
-    items = tuple(mapping.items())
+
+def _cache_enginx_run_number_cycle_map(
+    journal_dir: Path,
+    mapping: dict[int, str],
+    ttl_seconds: int,
+    now: float,
+) -> None:
     if mapping and ttl_seconds > 0:
         ENGINX_CACHE[journal_dir] = EnginxCacheEntry(
-            items=items,
+            items=tuple(mapping.items()),
             expires_at=now + ttl_seconds,
         )
     else:
         ENGINX_CACHE.pop(journal_dir, None)
-    return items
 
 
 def _clear_enginx_run_number_cycle_map_cache() -> None:
@@ -271,13 +277,22 @@ def build_enginx_run_number_cycle_map() -> dict[int, str]:
     :return: A dict[int, str] mapping run numbers to cycle strings.
     """
     ttl_seconds = _enginx_run_number_cycle_map_cache_ttl_seconds()
+    journal_dir = _enginx_journal_dir()
     if ttl_seconds > 0:
+        now = time.monotonic()
+        in_process_mapping = _get_cached_enginx_run_number_cycle_map(journal_dir, now)
+        if in_process_mapping:
+            return in_process_mapping
+
         cached_mapping = _coerce_run_number_cycle_map(cache_get_json(ENGINX_CACHE_KEY))
         if cached_mapping:
             logger.info("Using cached EnginX run number cycle map")
+            _cache_enginx_run_number_cycle_map(journal_dir, cached_mapping, ttl_seconds, now)
             return cached_mapping
 
-    mapping = dict(_cached_enginx_run_number_cycle_map(_enginx_journal_dir(), ttl_seconds))
+    mapping = _read_enginx_run_number_cycle_map(journal_dir)
+    if ttl_seconds > 0:
+        _cache_enginx_run_number_cycle_map(journal_dir, mapping, ttl_seconds, now)
     if ttl_seconds > 0 and mapping:
         cache_set_json(ENGINX_CACHE_KEY, mapping, ttl_seconds)
     return mapping

--- a/rundetection/rules/enginx_rules.py
+++ b/rundetection/rules/enginx_rules.py
@@ -30,7 +30,8 @@ class EnginxGroupRule(Rule[str]):
     """Insert the group type into the JobRequest."""
 
     def verify(self, job_request: JobRequest) -> None:
-        """Verify the rule against the job request.
+        """
+        Verify the rule against the job request.
 
         Adds the group type to the additional values after validating it
         against a list of valid group types.
@@ -58,7 +59,8 @@ class EnginxBasePathRule(Rule[int | str]):
     path_key: str = "x_path"  # example: "x_path", would be ceria_path, etc.
 
     def verify(self, job_request: JobRequest) -> None:
-        """Find the given ceria or vanadium file path and attach it to the job
+        """
+        Find the given ceria or vanadium file path and attach it to the job
         request.
 
         :param job_request: The job request to add to
@@ -84,13 +86,15 @@ class EnginxBasePathRule(Rule[int | str]):
 
     @classmethod
     def _find_path(cls, run: str) -> Path | None:
-        """Find a file ending with '0*{run}.nxs' (case-insensitive), where the
+        """
+        Find a file ending with '0*{run}.nxs' (case-insensitive), where the
         digit sequence is not preceded by another digit.
 
         Examples:
         ENGINX1234.nxs       ✓
         ENGINX0001234.nxs    ✓
         foo991234.nxs        ✗ (blocked by non-digit boundary)
+
         """
         # non-digit boundary, then any number of '0', then the run, then .nxs at end
         file_re = re.compile(rf"(?i)(?<!\d)0*{re.escape(run)}\.nxs$")
@@ -132,8 +136,10 @@ class EnginxCeriaPathRule(EnginxBasePathRule):
 
 
 class EnginxVanadiumPathRule(EnginxBasePathRule):
-    """Resolve and attach the Vanadium calibration file path for an EnginX
-    run."""
+    """
+    Resolve and attach the Vanadium calibration file path for an EnginX
+    run.
+    """
 
     path_key: str = "vanadium_path"
 
@@ -244,7 +250,8 @@ def _clear_enginx_run_number_cycle_map_cache() -> None:
 
 
 def build_enginx_run_number_cycle_map() -> dict[int, str]:
-    """Generate a mapping of run numbers to cycle strings based on the journal
+    """
+    Generate a mapping of run numbers to cycle strings based on the journal
     files.
 
     For example. mapping[242666] -> "15_1"

--- a/rundetection/rules/enginx_rules.py
+++ b/rundetection/rules/enginx_rules.py
@@ -43,12 +43,10 @@ class EnginxGroupRule(Rule[str]):
         """
         Verify the rule against the job request.
 
-        Adds the group type to the additional values after validating it
-        against a list of valid group types.
+        Adds the group type to the additional values after validating it against a list of valid group types.
 
         :param job_request: The job request to verify.
-        :raises RuleViolationError: If the group type is not in the list
-            of valid groups.
+        :raises RuleViolationError: If the group type is not in the list of valid groups.
         :return: None.
         """
         group = self._value
@@ -70,9 +68,7 @@ class EnginxBasePathRule(Rule[int | str]):
 
     def verify(self, job_request: JobRequest) -> None:
         """
-        Find the given ceria or vanadium file path and attach it to the job
-        request.
-
+        Find the given ceria or vanadium file path and attach it to the job request.
         :param job_request: The job request to add to
         :return: None
         """
@@ -97,14 +93,11 @@ class EnginxBasePathRule(Rule[int | str]):
     @classmethod
     def _find_path(cls, run: str) -> Path | None:
         """
-        Find a file ending with '0*{run}.nxs' (case-insensitive), where the
-        digit sequence is not preceded by another digit.
-
-        Examples:
-        ENGINX1234.nxs       ✓
-        ENGINX0001234.nxs    ✓
-        foo991234.nxs        ✗ (blocked by non-digit boundary)
-
+        Find a file ending with '0*{run}.nxs' (case-insensitive), where the digit
+        sequence is not preceded by another digit. Examples:
+          ENGINX1234.nxs       ✓
+          ENGINX0001234.nxs    ✓
+          foo991234.nxs        ✗ (blocked by non-digit boundary)
         """
         # non-digit boundary, then any number of '0', then the run, then .nxs at end
         file_re = re.compile(rf"(?i)(?<!\d)0*{re.escape(run)}\.nxs$")
@@ -146,10 +139,7 @@ class EnginxCeriaPathRule(EnginxBasePathRule):
 
 
 class EnginxVanadiumPathRule(EnginxBasePathRule):
-    """
-    Resolve and attach the Vanadium calibration file path for an EnginX
-    run.
-    """
+    """Resolve and attach the Vanadium calibration file path for an EnginX run."""
 
     path_key: str = "vanadium_path"
 

--- a/rundetection/rules/enginx_rules.py
+++ b/rundetection/rules/enginx_rules.py
@@ -6,6 +6,8 @@ import contextlib
 import logging
 import os
 import re
+import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Self
 
@@ -23,15 +25,22 @@ logger = logging.getLogger(__name__)
 ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY = "run_detection:enginx:run_number_cycle_map"
 ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_TTL_SECONDS = 60 * 60
 _ENGINX_RUN_NAME_PREFIX = "ENGINX"
-_ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE: dict[Path, tuple[tuple[int, str], ...]] = {}
+
+
+@dataclass(slots=True)
+class _EnginxRunNumberCycleMapCacheEntry:
+    items: tuple[tuple[int, str], ...]
+    expires_at: float
+
+
+_ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE: dict[Path, _EnginxRunNumberCycleMapCacheEntry] = {}
 
 
 class EnginxGroupRule(Rule[str]):
     """Insert the group type into the JobRequest."""
 
     def verify(self, job_request: JobRequest) -> None:
-        """
-        Verify the rule against the job request.
+        """Verify the rule against the job request.
 
         Adds the group type to the additional values after validating it
         against a list of valid group types.
@@ -59,8 +68,7 @@ class EnginxBasePathRule(Rule[int | str]):
     path_key: str = "x_path"  # example: "x_path", would be ceria_path, etc.
 
     def verify(self, job_request: JobRequest) -> None:
-        """
-        Find the given ceria or vanadium file path and attach it to the job
+        """Find the given ceria or vanadium file path and attach it to the job
         request.
 
         :param job_request: The job request to add to
@@ -86,15 +94,13 @@ class EnginxBasePathRule(Rule[int | str]):
 
     @classmethod
     def _find_path(cls, run: str) -> Path | None:
-        """
-        Find a file ending with '0*{run}.nxs' (case-insensitive), where the
+        """Find a file ending with '0*{run}.nxs' (case-insensitive), where the
         digit sequence is not preceded by another digit.
 
         Examples:
         ENGINX1234.nxs       ✓
         ENGINX0001234.nxs    ✓
         foo991234.nxs        ✗ (blocked by non-digit boundary)
-
         """
         # non-digit boundary, then any number of '0', then the run, then .nxs at end
         file_re = re.compile(rf"(?i)(?<!\d)0*{re.escape(run)}\.nxs$")
@@ -136,10 +142,8 @@ class EnginxCeriaPathRule(EnginxBasePathRule):
 
 
 class EnginxVanadiumPathRule(EnginxBasePathRule):
-    """
-    Resolve and attach the Vanadium calibration file path for an EnginX
-    run.
-    """
+    """Resolve and attach the Vanadium calibration file path for an EnginX
+    run."""
 
     path_key: str = "vanadium_path"
 
@@ -234,14 +238,24 @@ def _read_enginx_run_number_cycle_map(journal_dir: Path) -> dict[int, str]:
     return mapping
 
 
-def _cached_enginx_run_number_cycle_map(journal_dir: Path) -> tuple[tuple[int, str], ...]:
-    """Return a memoized run/cycle mapping read from EnginX journal files."""
-    if journal_dir not in _ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE:
-        mapping = _read_enginx_run_number_cycle_map(journal_dir)
-        if mapping:
-            _ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE[journal_dir] = tuple(mapping.items())
-        return tuple(mapping.items())
-    return _ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE[journal_dir]
+def _cached_enginx_run_number_cycle_map(journal_dir: Path, ttl_seconds: int) -> tuple[tuple[int, str], ...]:
+    """Return a TTL-limited run/cycle mapping read from EnginX journal
+    files."""
+    now = time.monotonic()
+    cached = _ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE.get(journal_dir)
+    if cached is not None and cached.expires_at > now:
+        return cached.items
+
+    mapping = _read_enginx_run_number_cycle_map(journal_dir)
+    items = tuple(mapping.items())
+    if mapping and ttl_seconds > 0:
+        _ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE[journal_dir] = _EnginxRunNumberCycleMapCacheEntry(
+            items=items,
+            expires_at=now + ttl_seconds,
+        )
+    else:
+        _ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE.pop(journal_dir, None)
+    return items
 
 
 def _clear_enginx_run_number_cycle_map_cache() -> None:
@@ -250,8 +264,7 @@ def _clear_enginx_run_number_cycle_map_cache() -> None:
 
 
 def build_enginx_run_number_cycle_map() -> dict[int, str]:
-    """
-    Generate a mapping of run numbers to cycle strings based on the journal
+    """Generate a mapping of run numbers to cycle strings based on the journal
     files.
 
     For example. mapping[242666] -> "15_1"
@@ -264,7 +277,7 @@ def build_enginx_run_number_cycle_map() -> dict[int, str]:
             logger.info("Using cached EnginX run number cycle map")
             return cached_mapping
 
-    mapping = dict(_cached_enginx_run_number_cycle_map(_enginx_journal_dir()))
+    mapping = dict(_cached_enginx_run_number_cycle_map(_enginx_journal_dir(), ttl_seconds))
     if ttl_seconds > 0 and mapping:
         cache_set_json(ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY, mapping, ttl_seconds)
     return mapping

--- a/rundetection/rules/enginx_rules.py
+++ b/rundetection/rules/enginx_rules.py
@@ -22,18 +22,18 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY = "run_detection:enginx:run_number_cycle_map"
-ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_TTL_SECONDS = 60 * 60
-_ENGINX_RUN_NAME_PREFIX = "ENGINX"
+ENGINX_CACHE_KEY = "run_detection:enginx:run_number_cycle_map"
+ENGINX_CACHE_TTL_SECONDS = 60 * 60
+ENGINX_PREFIX = "ENGINX"
 
 
 @dataclass(slots=True)
-class _EnginxRunNumberCycleMapCacheEntry:
+class EnginxCacheEntry:
     items: tuple[tuple[int, str], ...]
     expires_at: float
 
 
-_ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE: dict[Path, _EnginxRunNumberCycleMapCacheEntry] = {}
+ENGINX_CACHE: dict[Path, EnginxCacheEntry] = {}
 
 
 class EnginxGroupRule(Rule[str]):
@@ -164,12 +164,12 @@ def _enginx_journal_dir() -> Path:
 def _enginx_run_number_cycle_map_cache_ttl_seconds() -> int:
     configured_ttl = os.environ.get("ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_TTL_SECONDS")
     if configured_ttl is None:
-        return ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_TTL_SECONDS
+        return ENGINX_CACHE_TTL_SECONDS
     try:
         return int(configured_ttl)
     except ValueError:
         logger.warning("Invalid ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_TTL_SECONDS value: %s", configured_ttl)
-        return ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_TTL_SECONDS
+        return ENGINX_CACHE_TTL_SECONDS
 
 
 def _coerce_run_number_cycle_map(value: Any) -> dict[int, str] | None:
@@ -190,11 +190,11 @@ def _coerce_run_number_cycle_map(value: Any) -> dict[int, str] | None:
 def _add_enginx_run_to_cycle_map(mapping: dict[int, str], entry_name: Any, journal_file: str) -> bool:
     if not isinstance(entry_name, str):
         return False
-    if not entry_name.upper().startswith(_ENGINX_RUN_NAME_PREFIX):
+    if not entry_name.upper().startswith(ENGINX_PREFIX):
         return False
 
     with contextlib.suppress(ValueError):
-        mapping[int(entry_name[len(_ENGINX_RUN_NAME_PREFIX) :])] = journal_file.removeprefix("journal_")
+        mapping[int(entry_name[len(ENGINX_PREFIX) :])] = journal_file.removeprefix("journal_")
     return True
 
 
@@ -250,25 +250,25 @@ def _cached_enginx_run_number_cycle_map(journal_dir: Path, ttl_seconds: int) -> 
     files.
     """
     now = time.monotonic()
-    cached = _ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE.get(journal_dir)
+    cached = ENGINX_CACHE.get(journal_dir)
     if cached is not None and cached.expires_at > now:
         return cached.items
 
     mapping = _read_enginx_run_number_cycle_map(journal_dir)
     items = tuple(mapping.items())
     if mapping and ttl_seconds > 0:
-        _ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE[journal_dir] = _EnginxRunNumberCycleMapCacheEntry(
+        ENGINX_CACHE[journal_dir] = EnginxCacheEntry(
             items=items,
             expires_at=now + ttl_seconds,
         )
     else:
-        _ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE.pop(journal_dir, None)
+        ENGINX_CACHE.pop(journal_dir, None)
     return items
 
 
 def _clear_enginx_run_number_cycle_map_cache() -> None:
     """Clear the memoized EnginX journal mapping."""
-    _ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE.clear()
+    ENGINX_CACHE.clear()
 
 
 def build_enginx_run_number_cycle_map() -> dict[int, str]:
@@ -277,16 +277,17 @@ def build_enginx_run_number_cycle_map() -> dict[int, str]:
     files.
 
     For example. mapping[242666] -> "15_1"
+
     :return: A dict[int, str] mapping run numbers to cycle strings.
     """
     ttl_seconds = _enginx_run_number_cycle_map_cache_ttl_seconds()
     if ttl_seconds > 0:
-        cached_mapping = _coerce_run_number_cycle_map(cache_get_json(ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY))
+        cached_mapping = _coerce_run_number_cycle_map(cache_get_json(ENGINX_CACHE_KEY))
         if cached_mapping:
             logger.info("Using cached EnginX run number cycle map")
             return cached_mapping
 
     mapping = dict(_cached_enginx_run_number_cycle_map(_enginx_journal_dir(), ttl_seconds))
     if ttl_seconds > 0 and mapping:
-        cache_set_json(ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY, mapping, ttl_seconds)
+        cache_set_json(ENGINX_CACHE_KEY, mapping, ttl_seconds)
     return mapping

--- a/rundetection/run_detection.py
+++ b/rundetection/run_detection.py
@@ -19,6 +19,8 @@ from rundetection.ingestion.ingest import ingest
 from rundetection.rules.enginx_rules import build_enginx_run_number_cycle_map
 from rundetection.specifications import InstrumentSpecification
 
+
+
 if typing.TYPE_CHECKING:
     from collections.abc import Generator
     from typing import Any
@@ -40,7 +42,7 @@ logging.getLogger("pika").setLevel(logging.WARNING)
 INGRESS_QUEUE_NAME = os.environ.get("INGRESS_QUEUE_NAME", "watched-files")
 EGRESS_QUEUE_NAME = os.environ.get("EGRESS_QUEUE_NAME", "scheduled-jobs")
 FAILURE_QUEUE_NAME = os.environ.get("FAILURE_QUEUE_NAME", "failed-watched-files")
-
+ARCHIVE_ROOT = os.environ.get("ARCHIVE_ROOT", "/archive")
 
 def get_channel(exchange_name: str, queue_name: str) -> BlockingChannel:
     """

--- a/rundetection/run_detection.py
+++ b/rundetection/run_detection.py
@@ -19,8 +19,6 @@ from rundetection.ingestion.ingest import ingest
 from rundetection.rules.enginx_rules import build_enginx_run_number_cycle_map
 from rundetection.specifications import InstrumentSpecification
 
-
-
 if typing.TYPE_CHECKING:
     from collections.abc import Generator
     from typing import Any
@@ -43,6 +41,7 @@ INGRESS_QUEUE_NAME = os.environ.get("INGRESS_QUEUE_NAME", "watched-files")
 EGRESS_QUEUE_NAME = os.environ.get("EGRESS_QUEUE_NAME", "scheduled-jobs")
 FAILURE_QUEUE_NAME = os.environ.get("FAILURE_QUEUE_NAME", "failed-watched-files")
 ARCHIVE_ROOT = os.environ.get("ARCHIVE_ROOT", "/archive")
+
 
 def get_channel(exchange_name: str, queue_name: str) -> BlockingChannel:
     """

--- a/rundetection/run_detection.py
+++ b/rundetection/run_detection.py
@@ -40,16 +40,12 @@ logging.getLogger("pika").setLevel(logging.WARNING)
 INGRESS_QUEUE_NAME = os.environ.get("INGRESS_QUEUE_NAME", "watched-files")
 EGRESS_QUEUE_NAME = os.environ.get("EGRESS_QUEUE_NAME", "scheduled-jobs")
 FAILURE_QUEUE_NAME = os.environ.get("FAILURE_QUEUE_NAME", "failed-watched-files")
-ARCHIVE_ROOT = os.environ.get("ARCHIVE_ROOT", "/archive")
 
 
 def get_channel(exchange_name: str, queue_name: str) -> BlockingChannel:
-    """
-    Given an exchange and queue name, return a blocking channel to the exchange and queue
-    :param exchange_name: The exchange name
-    :param queue_name: The queue name
-    :return: The Blocking Channel.
-    """
+    """Given an exchange and queue name, return a blocking channel to the
+    exchange and queue :param exchange_name: The exchange name :param
+    queue_name: The queue name :return: The Blocking Channel."""
     credentials = PlainCredentials(
         username=os.environ.get("QUEUE_USER", "guest"), password=os.environ.get("QUEUE_PASSWORD", "guest")
     )
@@ -66,10 +62,8 @@ def get_channel(exchange_name: str, queue_name: str) -> BlockingChannel:
 
 @contextmanager
 def producer() -> Generator[BlockingChannel | BlockingChannel, Any, None]:
-    """
-    Return a context managed pika producer channel
-    :return: BlockingChannel.
-    """
+    """Return a context managed pika producer channel :return:
+    BlockingChannel."""
     logger.info("Creating producer...")
     channel = get_channel("scheduled-jobs", "scheduled-jobs")
     yield channel
@@ -80,9 +74,10 @@ def producer() -> Generator[BlockingChannel | BlockingChannel, Any, None]:
 
 
 def process_message(message: str, notification_queue: SimpleQueue[JobRequest]) -> None:
-    """
-    Process the incoming message. If the message should result in an upstream notification, it will put the message on
-    the given notification queue
+    """Process the incoming message.
+
+    If the message should result in an upstream notification, it will
+    put the message on the given notification queue
     :param message: The message to process
     :param notification_queue: The notification queue to update
     :return: None.
@@ -107,8 +102,8 @@ def process_messages(
     notification_queue: SimpleQueue[JobRequest],
     failure_queue: SimpleQueue[str],
 ) -> None:
-    """
-    Consume messages from the ingress and failure queues and enqueue valid notifications.
+    """Consume messages from the ingress and failure queues and enqueue valid
+    notifications.
 
     This function will attempt to consume at most one message from the ingress queue and at most one
     message from the failure queue per invocation (it breaks after each consume loop iteration). For
@@ -182,11 +177,8 @@ def process_messages(
 
 
 def process_notifications(notification_queue: SimpleQueue[JobRequest]) -> None:
-    """
-    Produce messages until the notification queue is empty
-    :param notification_queue: The notification queue
-    :return: None.
-    """
+    """Produce messages until the notification queue is empty :param
+    notification_queue: The notification queue :return: None."""
     while not notification_queue.empty():
         detected_run = notification_queue.get()
         logger.info("Sending notification for run: %s", detected_run.run_number)
@@ -196,11 +188,8 @@ def process_notifications(notification_queue: SimpleQueue[JobRequest]) -> None:
 
 
 def notify_failures(failure_queue: SimpleQueue[str]) -> None:
-    """
-    Produce Failure messages until the failure queue is empty
-    :param failure_queue: The failure Queue
-    :return: None
-    """
+    """Produce Failure messages until the failure queue is empty :param
+    failure_queue: The failure Queue :return: None."""
     while not failure_queue.empty():
         logger.info("Notifying failed-watched-files queue of messages failed to process")
         message = failure_queue.get()
@@ -210,8 +199,8 @@ def notify_failures(failure_queue: SimpleQueue[str]) -> None:
 
 
 def start_run_detection() -> None:
-    """
-    Start the producer and consumer in a loop.
+    """Start the producer and consumer in a loop.
+
     :return: None.
     """
     logger.info("Starting Run Detection")
@@ -245,18 +234,16 @@ def verify_archive_access() -> None:
 
 
 def pre_build_enginx_cycle_mapping() -> None:
-    """
-    Make an initial call to the enginx run_number_cycle_map to ensure it is cached ahead of time.
+    """Make an initial call to the enginx run_number_cycle_map to ensure it is
+    cached ahead of time.
+
     :return: None
     """
     build_enginx_run_number_cycle_map()
 
 
 def main() -> None:
-    """
-    Entry point for run detection
-    :return: None.
-    """
+    """Entry point for run detection :return: None."""
     verify_archive_access()
     heart_beat = Heartbeat()
     heart_beat.start()

--- a/rundetection/run_detection.py
+++ b/rundetection/run_detection.py
@@ -45,8 +45,11 @@ FAILURE_QUEUE_NAME = os.environ.get("FAILURE_QUEUE_NAME", "failed-watched-files"
 def get_channel(exchange_name: str, queue_name: str) -> BlockingChannel:
     """
     Given an exchange and queue name, return a blocking channel to the
-    exchange and queue :param exchange_name: The exchange name :param
-    queue_name: The queue name :return: The Blocking Channel.
+    exchange and queue.
+
+    :param exchange_name: The exchange name.
+    :param queue_name: The queue name.
+    :return: The Blocking Channel.
     """
     credentials = PlainCredentials(
         username=os.environ.get("QUEUE_USER", "guest"), password=os.environ.get("QUEUE_PASSWORD", "guest")
@@ -65,8 +68,9 @@ def get_channel(exchange_name: str, queue_name: str) -> BlockingChannel:
 @contextmanager
 def producer() -> Generator[BlockingChannel | BlockingChannel, Any, None]:
     """
-    Return a context managed pika producer channel :return:
-    BlockingChannel.
+    Return a context managed pika producer channel.
+
+    :return: BlockingChannel.
     """
     logger.info("Creating producer...")
     channel = get_channel("scheduled-jobs", "scheduled-jobs")
@@ -82,7 +86,8 @@ def process_message(message: str, notification_queue: SimpleQueue[JobRequest]) -
     Process the incoming message.
 
     If the message should result in an upstream notification, it will
-    put the message on the given notification queue
+    put the message on the given notification queue.
+
     :param message: The message to process
     :param notification_queue: The notification queue to update
     :return: None.
@@ -185,8 +190,10 @@ def process_messages(
 
 def process_notifications(notification_queue: SimpleQueue[JobRequest]) -> None:
     """
-    Produce messages until the notification queue is empty :param
-    notification_queue: The notification queue :return: None.
+    Produce messages until the notification queue is empty.
+
+    :param notification_queue: The notification queue.
+    :return: None.
     """
     while not notification_queue.empty():
         detected_run = notification_queue.get()
@@ -198,8 +205,10 @@ def process_notifications(notification_queue: SimpleQueue[JobRequest]) -> None:
 
 def notify_failures(failure_queue: SimpleQueue[str]) -> None:
     """
-    Produce Failure messages until the failure queue is empty :param
-    failure_queue: The failure Queue :return: None.
+    Produce Failure messages until the failure queue is empty.
+
+    :param failure_queue: The failure Queue.
+    :return: None.
     """
     while not failure_queue.empty():
         logger.info("Notifying failed-watched-files queue of messages failed to process")
@@ -256,7 +265,11 @@ def pre_build_enginx_cycle_mapping() -> None:
 
 
 def main() -> None:
-    """Entry point for run detection :return: None."""
+    """
+    Entry point for run detection.
+
+    :return: None.
+    """
     verify_archive_access()
     heart_beat = Heartbeat()
     heart_beat.start()

--- a/rundetection/run_detection.py
+++ b/rundetection/run_detection.py
@@ -43,9 +43,11 @@ FAILURE_QUEUE_NAME = os.environ.get("FAILURE_QUEUE_NAME", "failed-watched-files"
 
 
 def get_channel(exchange_name: str, queue_name: str) -> BlockingChannel:
-    """Given an exchange and queue name, return a blocking channel to the
+    """
+    Given an exchange and queue name, return a blocking channel to the
     exchange and queue :param exchange_name: The exchange name :param
-    queue_name: The queue name :return: The Blocking Channel."""
+    queue_name: The queue name :return: The Blocking Channel.
+    """
     credentials = PlainCredentials(
         username=os.environ.get("QUEUE_USER", "guest"), password=os.environ.get("QUEUE_PASSWORD", "guest")
     )
@@ -62,8 +64,10 @@ def get_channel(exchange_name: str, queue_name: str) -> BlockingChannel:
 
 @contextmanager
 def producer() -> Generator[BlockingChannel | BlockingChannel, Any, None]:
-    """Return a context managed pika producer channel :return:
-    BlockingChannel."""
+    """
+    Return a context managed pika producer channel :return:
+    BlockingChannel.
+    """
     logger.info("Creating producer...")
     channel = get_channel("scheduled-jobs", "scheduled-jobs")
     yield channel
@@ -74,7 +78,8 @@ def producer() -> Generator[BlockingChannel | BlockingChannel, Any, None]:
 
 
 def process_message(message: str, notification_queue: SimpleQueue[JobRequest]) -> None:
-    """Process the incoming message.
+    """
+    Process the incoming message.
 
     If the message should result in an upstream notification, it will
     put the message on the given notification queue
@@ -102,7 +107,8 @@ def process_messages(
     notification_queue: SimpleQueue[JobRequest],
     failure_queue: SimpleQueue[str],
 ) -> None:
-    """Consume messages from the ingress and failure queues and enqueue valid
+    """
+    Consume messages from the ingress and failure queues and enqueue valid
     notifications.
 
     This function will attempt to consume at most one message from the ingress queue and at most one
@@ -178,8 +184,10 @@ def process_messages(
 
 
 def process_notifications(notification_queue: SimpleQueue[JobRequest]) -> None:
-    """Produce messages until the notification queue is empty :param
-    notification_queue: The notification queue :return: None."""
+    """
+    Produce messages until the notification queue is empty :param
+    notification_queue: The notification queue :return: None.
+    """
     while not notification_queue.empty():
         detected_run = notification_queue.get()
         logger.info("Sending notification for run: %s", detected_run.run_number)
@@ -189,8 +197,10 @@ def process_notifications(notification_queue: SimpleQueue[JobRequest]) -> None:
 
 
 def notify_failures(failure_queue: SimpleQueue[str]) -> None:
-    """Produce Failure messages until the failure queue is empty :param
-    failure_queue: The failure Queue :return: None."""
+    """
+    Produce Failure messages until the failure queue is empty :param
+    failure_queue: The failure Queue :return: None.
+    """
     while not failure_queue.empty():
         logger.info("Notifying failed-watched-files queue of messages failed to process")
         message = failure_queue.get()
@@ -200,7 +210,8 @@ def notify_failures(failure_queue: SimpleQueue[str]) -> None:
 
 
 def start_run_detection() -> None:
-    """Start the producer and consumer in a loop.
+    """
+    Start the producer and consumer in a loop.
 
     :return: None.
     """
@@ -235,7 +246,8 @@ def verify_archive_access() -> None:
 
 
 def pre_build_enginx_cycle_mapping() -> None:
-    """Make an initial call to the enginx run_number_cycle_map to ensure it is
+    """
+    Make an initial call to the enginx run_number_cycle_map to ensure it is
     cached ahead of time.
 
     :return: None

--- a/rundetection/run_detection.py
+++ b/rundetection/run_detection.py
@@ -44,9 +44,7 @@ FAILURE_QUEUE_NAME = os.environ.get("FAILURE_QUEUE_NAME", "failed-watched-files"
 
 def get_channel(exchange_name: str, queue_name: str) -> BlockingChannel:
     """
-    Given an exchange and queue name, return a blocking channel to the
-    exchange and queue.
-
+    Given an exchange and queue name, return a blocking channel to the exchange and queue.
     :param exchange_name: The exchange name.
     :param queue_name: The queue name.
     :return: The Blocking Channel.
@@ -69,7 +67,6 @@ def get_channel(exchange_name: str, queue_name: str) -> BlockingChannel:
 def producer() -> Generator[BlockingChannel | BlockingChannel, Any, None]:
     """
     Return a context managed pika producer channel.
-
     :return: BlockingChannel.
     """
     logger.info("Creating producer...")
@@ -83,11 +80,8 @@ def producer() -> Generator[BlockingChannel | BlockingChannel, Any, None]:
 
 def process_message(message: str, notification_queue: SimpleQueue[JobRequest]) -> None:
     """
-    Process the incoming message.
-
-    If the message should result in an upstream notification, it will
-    put the message on the given notification queue.
-
+    Process the incoming message. If the message should result in an upstream notification, it will put the message on
+    the given notification queue.
     :param message: The message to process
     :param notification_queue: The notification queue to update
     :return: None.
@@ -113,8 +107,7 @@ def process_messages(
     failure_queue: SimpleQueue[str],
 ) -> None:
     """
-    Consume messages from the ingress and failure queues and enqueue valid
-    notifications.
+    Consume messages from the ingress and failure queues and enqueue valid notifications.
 
     This function will attempt to consume at most one message from the ingress queue and at most one
     message from the failure queue per invocation (it breaks after each consume loop iteration). For
@@ -191,7 +184,6 @@ def process_messages(
 def process_notifications(notification_queue: SimpleQueue[JobRequest]) -> None:
     """
     Produce messages until the notification queue is empty.
-
     :param notification_queue: The notification queue.
     :return: None.
     """
@@ -206,7 +198,6 @@ def process_notifications(notification_queue: SimpleQueue[JobRequest]) -> None:
 def notify_failures(failure_queue: SimpleQueue[str]) -> None:
     """
     Produce Failure messages until the failure queue is empty.
-
     :param failure_queue: The failure Queue.
     :return: None.
     """
@@ -221,7 +212,6 @@ def notify_failures(failure_queue: SimpleQueue[str]) -> None:
 def start_run_detection() -> None:
     """
     Start the producer and consumer in a loop.
-
     :return: None.
     """
     logger.info("Starting Run Detection")
@@ -256,9 +246,7 @@ def verify_archive_access() -> None:
 
 def pre_build_enginx_cycle_mapping() -> None:
     """
-    Make an initial call to the enginx run_number_cycle_map to ensure it is
-    cached ahead of time.
-
+    Make an initial call to the enginx run_number_cycle_map to ensure it is cached ahead of time.
     :return: None
     """
     build_enginx_run_number_cycle_map()
@@ -267,7 +255,6 @@ def pre_build_enginx_cycle_mapping() -> None:
 def main() -> None:
     """
     Entry point for run detection.
-
     :return: None.
     """
     verify_archive_access()

--- a/test/rules/test_enginx_rules.py
+++ b/test/rules/test_enginx_rules.py
@@ -8,10 +8,12 @@ import pytest
 from rundetection.exceptions import RuleViolationError
 from rundetection.ingestion.ingest import JobRequest
 from rundetection.rules.enginx_rules import (
+    ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY,
     EnginxBasePathRule,
     EnginxCeriaPathRule,
     EnginxGroupRule,
     EnginxVanadiumPathRule,
+    build_enginx_run_number_cycle_map,
 )
 
 
@@ -117,3 +119,55 @@ def test_coerce_run_invalid_raises():
     """Test that invalid run raises an exception."""
     with pytest.raises(ValueError):  # noqa: PT011
         EnginxBasePathRule._coerce_run("no-digits")
+
+
+@patch("rundetection.rules.enginx_rules.cache_set_json")
+@patch("rundetection.rules.enginx_rules.cache_get_json", return_value={"241391": "20_1"})
+def test_build_enginx_run_number_cycle_map_uses_cached_mapping(mock_cache_get, mock_cache_set):
+    """Cached JSON mapping is returned with run numbers coerced back to ints."""
+    assert build_enginx_run_number_cycle_map() == {241391: "20_1"}
+    mock_cache_get.assert_called_once_with(ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY)
+    mock_cache_set.assert_not_called()
+
+
+@patch("rundetection.rules.enginx_rules.cache_set_json")
+@patch("rundetection.rules.enginx_rules.cache_get_json", return_value=None)
+def test_build_enginx_run_number_cycle_map_reads_journals_and_populates_cache(
+    mock_cache_get,
+    mock_cache_set,
+    monkeypatch,
+):
+    """A cache miss reads journal files and stores the parsed mapping."""
+    monkeypatch.setenv(
+        "ENGINX_JOURNAL_DIR",
+        "test/test_data/e2e_data/NDXENGINX/Instrument/logs/journal",
+    )
+    monkeypatch.setenv("ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_TTL_SECONDS", "123")
+
+    mapping = build_enginx_run_number_cycle_map()
+
+    assert mapping[241391] == "20_1"
+    assert mapping[299080] == "20_1"
+    mock_cache_get.assert_called_once_with(ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY)
+    mock_cache_set.assert_called_once_with(ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY, mapping, 123)
+
+
+@patch("rundetection.rules.enginx_rules.cache_set_json")
+@patch("rundetection.rules.enginx_rules.cache_get_json")
+def test_build_enginx_run_number_cycle_map_skips_cache_when_ttl_disabled(
+    mock_cache_get,
+    mock_cache_set,
+    monkeypatch,
+):
+    """A non-positive TTL disables the Valkey read/write path."""
+    monkeypatch.setenv(
+        "ENGINX_JOURNAL_DIR",
+        "test/test_data/e2e_data/NDXENGINX/Instrument/logs/journal",
+    )
+    monkeypatch.setenv("ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_TTL_SECONDS", "0")
+
+    mapping = build_enginx_run_number_cycle_map()
+
+    assert mapping[241391] == "20_1"
+    mock_cache_get.assert_not_called()
+    mock_cache_set.assert_not_called()

--- a/test/rules/test_enginx_rules.py
+++ b/test/rules/test_enginx_rules.py
@@ -1,5 +1,6 @@
 """Tests for Enginx rules (group and path resolution)."""
 
+import logging
 from pathlib import Path
 from unittest.mock import patch
 
@@ -13,16 +14,15 @@ from rundetection.rules.enginx_rules import (
     EnginxCeriaPathRule,
     EnginxGroupRule,
     EnginxVanadiumPathRule,
+    _clear_enginx_run_number_cycle_map_cache,
+    _read_enginx_run_number_cycle_map,
     build_enginx_run_number_cycle_map,
 )
 
 
 @pytest.fixture
 def job_request():
-    """
-    Job request fixture
-    :return: job request.
-    """
+    """Job request fixture :return: job request."""
     return JobRequest(
         run_number=100,
         filepath=Path("/archive/100/ENGINX100.nxs"),
@@ -39,8 +39,17 @@ def job_request():
     )
 
 
+@pytest.fixture(autouse=True)
+def reset_enginx_run_number_cycle_map_cache():
+    """Clear the in-process EnginX journal mapping cache around each test."""
+    _clear_enginx_run_number_cycle_map_cache()
+    yield
+    _clear_enginx_run_number_cycle_map_cache()
+
+
 def test_enginx_group_rule_valid_values(job_request):
-    """Test that valid group values are accepted and set in additional_values"""
+    """Test that valid group values are accepted and set in
+    additional_values."""
     valid_groups = ["both", "north", "south", "cropped", "custom", "texture20", "texture30"]
     for group in valid_groups:
         jr = job_request
@@ -50,7 +59,7 @@ def test_enginx_group_rule_valid_values(job_request):
 
 
 def test_enginx_group_rule_invalid_value_raises(job_request):
-    """Test that an invalid group raises an exception"""
+    """Test that an invalid group raises an exception."""
     with pytest.raises(RuleViolationError):
         EnginxGroupRule("invalid_group").verify(job_request)
 
@@ -66,7 +75,8 @@ def test_enginx_group_rule_invalid_value_raises(job_request):
     "rundetection.rules.enginx_rules.build_enginx_run_number_cycle_map", return_value={241391: "20_1", 299080: "20_1"}
 )
 def test_enginx_ceria_path_rule_finds_file(mock_map, run, expected_file, job_request, monkeypatch):
-    """Test that EnginxCeriaPathRule sets ceria_run and ceria_path when file exists."""
+    """Test that EnginxCeriaPathRule sets ceria_run and ceria_path when file
+    exists."""
     # Point the root to test data
     monkeypatch.setattr(EnginxBasePathRule, "_ROOT", Path("test/test_data/e2e_data/NDXENGINX/Instrument/data"))
 
@@ -81,7 +91,8 @@ def test_enginx_ceria_path_rule_finds_file(mock_map, run, expected_file, job_req
 
 @patch("rundetection.rules.enginx_rules.build_enginx_run_number_cycle_map", return_value={241391: "20_1"})
 def test_enginx_vanadium_path_rule_finds_file(mock_map, job_request, monkeypatch):
-    """Test that EnginxVanadiumPathRule sets the vanadium path when the file exists."""
+    """Test that EnginxVanadiumPathRule sets the vanadium path when the file
+    exists."""
     monkeypatch.setattr(EnginxBasePathRule, "_ROOT", Path("test/test_data/e2e_data/NDXENGINX/Instrument/data"))
     rule = EnginxVanadiumPathRule(241391)
     rule.verify(job_request)
@@ -90,7 +101,8 @@ def test_enginx_vanadium_path_rule_finds_file(mock_map, job_request, monkeypatch
 
 
 def test_enginx_path_rule_not_found(job_request, monkeypatch):
-    """If run cannot be found, no exception and no path_key set, but ceria_run still set."""
+    """If run cannot be found, no exception and no path_key set, but ceria_run
+    still set."""
     # Ensure latest cycle dir points to test data but run is missing
     monkeypatch.setattr(EnginxBasePathRule, "_ROOT", Path("test/test_data/e2e_data/NDXENGINX/Instrument/data"))
 
@@ -124,7 +136,8 @@ def test_coerce_run_invalid_raises():
 @patch("rundetection.rules.enginx_rules.cache_set_json")
 @patch("rundetection.rules.enginx_rules.cache_get_json", return_value={"241391": "20_1"})
 def test_build_enginx_run_number_cycle_map_uses_cached_mapping(mock_cache_get, mock_cache_set):
-    """Cached JSON mapping is returned with run numbers coerced back to ints."""
+    """Cached JSON mapping is returned with run numbers coerced back to
+    ints."""
     assert build_enginx_run_number_cycle_map() == {241391: "20_1"}
     mock_cache_get.assert_called_once_with(ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY)
     mock_cache_set.assert_not_called()
@@ -171,3 +184,121 @@ def test_build_enginx_run_number_cycle_map_skips_cache_when_ttl_disabled(
     assert mapping[241391] == "20_1"
     mock_cache_get.assert_not_called()
     mock_cache_set.assert_not_called()
+
+
+def test_read_enginx_run_number_cycle_map_warns_when_journal_dir_missing(
+    tmp_path,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Missing journal directories return an empty mapping with a clear
+    warning."""
+    caplog.set_level(logging.WARNING)
+    journal_dir = tmp_path / "missing"
+
+    assert _read_enginx_run_number_cycle_map(journal_dir) == {}
+
+    assert f"EnginX journal directory does not exist: {journal_dir}" in caplog.text
+
+
+def test_read_enginx_run_number_cycle_map_warns_when_journal_path_is_not_dir(
+    tmp_path,
+    caplog: pytest.LogCaptureFixture,
+):
+    """A configured journal path that is a file is reported clearly."""
+    caplog.set_level(logging.WARNING)
+    journal_dir = tmp_path / "journal.xml"
+    journal_dir.write_text("")
+
+    assert _read_enginx_run_number_cycle_map(journal_dir) == {}
+
+    assert f"EnginX journal path is not a directory: {journal_dir}" in caplog.text
+
+
+def test_read_enginx_run_number_cycle_map_warns_when_no_xml_files_found(
+    tmp_path,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Empty journal directories return an empty mapping with a clear
+    warning."""
+    caplog.set_level(logging.WARNING)
+
+    assert _read_enginx_run_number_cycle_map(tmp_path) == {}
+
+    assert f"No EnginX journal XML files found in {tmp_path}" in caplog.text
+
+
+@patch("rundetection.rules.enginx_rules.cache_set_json")
+@patch("rundetection.rules.enginx_rules.cache_get_json")
+def test_build_enginx_run_number_cycle_map_does_not_cache_empty_mapping(
+    mock_cache_get,
+    mock_cache_set,
+    monkeypatch,
+    tmp_path,
+):
+    """Empty journal mappings are not stored locally or in Valkey."""
+    monkeypatch.setenv("ENGINX_JOURNAL_DIR", str(tmp_path))
+    monkeypatch.setenv("ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_TTL_SECONDS", "123")
+    mock_cache_get.return_value = None
+
+    with patch("rundetection.rules.enginx_rules._read_enginx_run_number_cycle_map", return_value={}) as mock_read:
+        assert build_enginx_run_number_cycle_map() == {}
+        assert build_enginx_run_number_cycle_map() == {}
+
+    assert mock_read.call_count == 2
+    assert mock_cache_get.call_count == 2
+    mock_cache_set.assert_not_called()
+
+
+@patch("rundetection.rules.enginx_rules.cache_set_json")
+@patch("rundetection.rules.enginx_rules.cache_get_json")
+def test_build_enginx_run_number_cycle_map_memoizes_journal_reads_when_ttl_disabled(
+    mock_cache_get,
+    mock_cache_set,
+    monkeypatch,
+):
+    """When Valkey is disabled by TTL, journal XML is only parsed once per
+    process."""
+    monkeypatch.setenv(
+        "ENGINX_JOURNAL_DIR",
+        "test/test_data/e2e_data/NDXENGINX/Instrument/logs/journal",
+    )
+    monkeypatch.setenv("ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_TTL_SECONDS", "0")
+
+    with patch(
+        "rundetection.rules.enginx_rules._read_enginx_run_number_cycle_map",
+        wraps=_read_enginx_run_number_cycle_map,
+    ) as mock_read:
+        first_mapping = build_enginx_run_number_cycle_map()
+        first_mapping[241391] = "mutated"
+        second_mapping = build_enginx_run_number_cycle_map()
+
+    assert second_mapping[241391] == "20_1"
+    mock_read.assert_called_once()
+    mock_cache_get.assert_not_called()
+    mock_cache_set.assert_not_called()
+
+
+@patch("rundetection.rules.enginx_rules.cache_set_json")
+@patch("rundetection.rules.enginx_rules.cache_get_json", return_value=None)
+def test_build_enginx_run_number_cycle_map_memoizes_journal_reads_after_valkey_miss(
+    mock_cache_get,
+    mock_cache_set,
+    monkeypatch,
+):
+    """Repeated Valkey misses reuse the in-process journal mapping."""
+    monkeypatch.setenv(
+        "ENGINX_JOURNAL_DIR",
+        "test/test_data/e2e_data/NDXENGINX/Instrument/logs/journal",
+    )
+    monkeypatch.setenv("ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_TTL_SECONDS", "123")
+
+    with patch(
+        "rundetection.rules.enginx_rules._read_enginx_run_number_cycle_map",
+        wraps=_read_enginx_run_number_cycle_map,
+    ) as mock_read:
+        assert build_enginx_run_number_cycle_map()[241391] == "20_1"
+        assert build_enginx_run_number_cycle_map()[241391] == "20_1"
+
+    mock_read.assert_called_once()
+    assert mock_cache_get.call_count == 2
+    assert mock_cache_set.call_count == 2

--- a/test/rules/test_enginx_rules.py
+++ b/test/rules/test_enginx_rules.py
@@ -50,8 +50,10 @@ def reset_enginx_run_number_cycle_map_cache():
 
 
 def test_enginx_group_rule_valid_values(job_request):
-    """Test that valid group values are accepted and set in
-    additional_values."""
+    """
+    Test that valid group values are accepted and set in
+    additional_values.
+    """
     valid_groups = ["both", "north", "south", "cropped", "custom", "texture20", "texture30"]
     for group in valid_groups:
         jr = job_request
@@ -77,8 +79,10 @@ def test_enginx_group_rule_invalid_value_raises(job_request):
     "rundetection.rules.enginx_rules.build_enginx_run_number_cycle_map", return_value={241391: "20_1", 299080: "20_1"}
 )
 def test_enginx_ceria_path_rule_finds_file(mock_map, run, expected_file, job_request, monkeypatch):
-    """Test that EnginxCeriaPathRule sets ceria_run and ceria_path when file
-    exists."""
+    """
+    Test that EnginxCeriaPathRule sets ceria_run and ceria_path when file
+    exists.
+    """
     # Point the root to test data
     monkeypatch.setattr(EnginxBasePathRule, "_ROOT", Path("test/test_data/e2e_data/NDXENGINX/Instrument/data"))
 
@@ -93,8 +97,10 @@ def test_enginx_ceria_path_rule_finds_file(mock_map, run, expected_file, job_req
 
 @patch("rundetection.rules.enginx_rules.build_enginx_run_number_cycle_map", return_value={241391: "20_1"})
 def test_enginx_vanadium_path_rule_finds_file(mock_map, job_request, monkeypatch):
-    """Test that EnginxVanadiumPathRule sets the vanadium path when the file
-    exists."""
+    """
+    Test that EnginxVanadiumPathRule sets the vanadium path when the file
+    exists.
+    """
     monkeypatch.setattr(EnginxBasePathRule, "_ROOT", Path("test/test_data/e2e_data/NDXENGINX/Instrument/data"))
     rule = EnginxVanadiumPathRule(241391)
     rule.verify(job_request)
@@ -103,8 +109,10 @@ def test_enginx_vanadium_path_rule_finds_file(mock_map, job_request, monkeypatch
 
 
 def test_enginx_path_rule_not_found(job_request, monkeypatch):
-    """If run cannot be found, no exception and no path_key set, but ceria_run
-    still set."""
+    """
+    If run cannot be found, no exception and no path_key set, but ceria_run
+    still set.
+    """
     # Ensure latest cycle dir points to test data but run is missing
     monkeypatch.setattr(EnginxBasePathRule, "_ROOT", Path("test/test_data/e2e_data/NDXENGINX/Instrument/data"))
 
@@ -138,8 +146,10 @@ def test_coerce_run_invalid_raises():
 @patch("rundetection.rules.enginx_rules.cache_set_json")
 @patch("rundetection.rules.enginx_rules.cache_get_json", return_value={"241391": "20_1"})
 def test_build_enginx_run_number_cycle_map_uses_cached_mapping(mock_cache_get, mock_cache_set):
-    """Cached JSON mapping is returned with run numbers coerced back to
-    ints."""
+    """
+    Cached JSON mapping is returned with run numbers coerced back to
+    ints.
+    """
     assert build_enginx_run_number_cycle_map() == {241391: "20_1"}
     mock_cache_get.assert_called_once_with(ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY)
     mock_cache_set.assert_not_called()
@@ -192,8 +202,10 @@ def test_read_enginx_run_number_cycle_map_warns_when_journal_dir_missing(
     tmp_path,
     caplog: pytest.LogCaptureFixture,
 ):
-    """Missing journal directories return an empty mapping with a clear
-    warning."""
+    """
+    Missing journal directories return an empty mapping with a clear
+    warning.
+    """
     caplog.set_level(logging.WARNING)
     journal_dir = tmp_path / "missing"
 
@@ -220,8 +232,10 @@ def test_read_enginx_run_number_cycle_map_warns_when_no_xml_files_found(
     tmp_path,
     caplog: pytest.LogCaptureFixture,
 ):
-    """Empty journal directories return an empty mapping with a clear
-    warning."""
+    """
+    Empty journal directories return an empty mapping with a clear
+    warning.
+    """
     caplog.set_level(logging.WARNING)
 
     assert _read_enginx_run_number_cycle_map(tmp_path) == {}
@@ -258,8 +272,10 @@ def test_build_enginx_run_number_cycle_map_memoizes_journal_reads_when_ttl_disab
     mock_cache_set,
     monkeypatch,
 ):
-    """When Valkey is disabled by TTL, journal XML is only parsed once per
-    process."""
+    """
+    When Valkey is disabled by TTL, journal XML is only parsed once per
+    process.
+    """
     monkeypatch.setenv(
         "ENGINX_JOURNAL_DIR",
         "test/test_data/e2e_data/NDXENGINX/Instrument/logs/journal",

--- a/test/rules/test_enginx_rules.py
+++ b/test/rules/test_enginx_rules.py
@@ -50,10 +50,8 @@ def reset_enginx_run_number_cycle_map_cache():
 
 
 def test_enginx_group_rule_valid_values(job_request):
-    """
-    Test that valid group values are accepted and set in
-    additional_values.
-    """
+    """Test that valid group values are accepted and set in
+    additional_values."""
     valid_groups = ["both", "north", "south", "cropped", "custom", "texture20", "texture30"]
     for group in valid_groups:
         jr = job_request
@@ -79,10 +77,8 @@ def test_enginx_group_rule_invalid_value_raises(job_request):
     "rundetection.rules.enginx_rules.build_enginx_run_number_cycle_map", return_value={241391: "20_1", 299080: "20_1"}
 )
 def test_enginx_ceria_path_rule_finds_file(mock_map, run, expected_file, job_request, monkeypatch):
-    """
-    Test that EnginxCeriaPathRule sets ceria_run and ceria_path when file
-    exists.
-    """
+    """Test that EnginxCeriaPathRule sets ceria_run and ceria_path when file
+    exists."""
     # Point the root to test data
     monkeypatch.setattr(EnginxBasePathRule, "_ROOT", Path("test/test_data/e2e_data/NDXENGINX/Instrument/data"))
 
@@ -97,10 +93,8 @@ def test_enginx_ceria_path_rule_finds_file(mock_map, run, expected_file, job_req
 
 @patch("rundetection.rules.enginx_rules.build_enginx_run_number_cycle_map", return_value={241391: "20_1"})
 def test_enginx_vanadium_path_rule_finds_file(mock_map, job_request, monkeypatch):
-    """
-    Test that EnginxVanadiumPathRule sets the vanadium path when the file
-    exists.
-    """
+    """Test that EnginxVanadiumPathRule sets the vanadium path when the file
+    exists."""
     monkeypatch.setattr(EnginxBasePathRule, "_ROOT", Path("test/test_data/e2e_data/NDXENGINX/Instrument/data"))
     rule = EnginxVanadiumPathRule(241391)
     rule.verify(job_request)
@@ -109,10 +103,8 @@ def test_enginx_vanadium_path_rule_finds_file(mock_map, job_request, monkeypatch
 
 
 def test_enginx_path_rule_not_found(job_request, monkeypatch):
-    """
-    If run cannot be found, no exception and no path_key set, but ceria_run
-    still set.
-    """
+    """If run cannot be found, no exception and no path_key set, but ceria_run
+    still set."""
     # Ensure latest cycle dir points to test data but run is missing
     monkeypatch.setattr(EnginxBasePathRule, "_ROOT", Path("test/test_data/e2e_data/NDXENGINX/Instrument/data"))
 
@@ -146,10 +138,8 @@ def test_coerce_run_invalid_raises():
 @patch("rundetection.rules.enginx_rules.cache_set_json")
 @patch("rundetection.rules.enginx_rules.cache_get_json", return_value={"241391": "20_1"})
 def test_build_enginx_run_number_cycle_map_uses_cached_mapping(mock_cache_get, mock_cache_set):
-    """
-    Cached JSON mapping is returned with run numbers coerced back to
-    ints.
-    """
+    """Cached JSON mapping is returned with run numbers coerced back to
+    ints."""
     assert build_enginx_run_number_cycle_map() == {241391: "20_1"}
     mock_cache_get.assert_called_once_with(ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY)
     mock_cache_set.assert_not_called()
@@ -202,10 +192,8 @@ def test_read_enginx_run_number_cycle_map_warns_when_journal_dir_missing(
     tmp_path,
     caplog: pytest.LogCaptureFixture,
 ):
-    """
-    Missing journal directories return an empty mapping with a clear
-    warning.
-    """
+    """Missing journal directories return an empty mapping with a clear
+    warning."""
     caplog.set_level(logging.WARNING)
     journal_dir = tmp_path / "missing"
 
@@ -232,10 +220,8 @@ def test_read_enginx_run_number_cycle_map_warns_when_no_xml_files_found(
     tmp_path,
     caplog: pytest.LogCaptureFixture,
 ):
-    """
-    Empty journal directories return an empty mapping with a clear
-    warning.
-    """
+    """Empty journal directories return an empty mapping with a clear
+    warning."""
     caplog.set_level(logging.WARNING)
 
     assert _read_enginx_run_number_cycle_map(tmp_path) == {}
@@ -267,15 +253,12 @@ def test_build_enginx_run_number_cycle_map_does_not_cache_empty_mapping(
 
 @patch("rundetection.rules.enginx_rules.cache_set_json")
 @patch("rundetection.rules.enginx_rules.cache_get_json")
-def test_build_enginx_run_number_cycle_map_memoizes_journal_reads_when_ttl_disabled(
+def test_build_enginx_run_number_cycle_map_reads_journals_when_ttl_disabled(
     mock_cache_get,
     mock_cache_set,
     monkeypatch,
 ):
-    """
-    When Valkey is disabled by TTL, journal XML is only parsed once per
-    process.
-    """
+    """When caching is disabled by TTL, journal XML is parsed per call."""
     monkeypatch.setenv(
         "ENGINX_JOURNAL_DIR",
         "test/test_data/e2e_data/NDXENGINX/Instrument/logs/journal",
@@ -291,7 +274,7 @@ def test_build_enginx_run_number_cycle_map_memoizes_journal_reads_when_ttl_disab
         second_mapping = build_enginx_run_number_cycle_map()
 
     assert second_mapping[241391] == "20_1"
-    mock_read.assert_called_once()
+    assert mock_read.call_count == REPEATED_BUILD_CALL_COUNT
     mock_cache_get.assert_not_called()
     mock_cache_set.assert_not_called()
 
@@ -318,5 +301,31 @@ def test_build_enginx_run_number_cycle_map_memoizes_journal_reads_after_valkey_m
         assert build_enginx_run_number_cycle_map()[241391] == "20_1"
 
     mock_read.assert_called_once()
+    assert mock_cache_get.call_count == REPEATED_BUILD_CALL_COUNT
+    assert mock_cache_set.call_count == REPEATED_BUILD_CALL_COUNT
+
+
+@patch("rundetection.rules.enginx_rules.cache_set_json")
+@patch("rundetection.rules.enginx_rules.cache_get_json", return_value=None)
+def test_build_enginx_run_number_cycle_map_refreshes_expired_local_cache(
+    mock_cache_get,
+    mock_cache_set,
+    monkeypatch,
+):
+    """Expired in-process cache entries are reread from journal files."""
+    monkeypatch.setenv("ENGINX_JOURNAL_DIR", "journal")
+    monkeypatch.setenv("ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_TTL_SECONDS", "50")
+
+    with (
+        patch(
+            "rundetection.rules.enginx_rules._read_enginx_run_number_cycle_map",
+            side_effect=[{241391: "20_1"}, {241391: "21_1"}],
+        ) as mock_read,
+        patch("rundetection.rules.enginx_rules.time.monotonic", side_effect=[100.0, 151.0]),
+    ):
+        assert build_enginx_run_number_cycle_map()[241391] == "20_1"
+        assert build_enginx_run_number_cycle_map()[241391] == "21_1"
+
+    assert mock_read.call_count == REPEATED_BUILD_CALL_COUNT
     assert mock_cache_get.call_count == REPEATED_BUILD_CALL_COUNT
     assert mock_cache_set.call_count == REPEATED_BUILD_CALL_COUNT

--- a/test/rules/test_enginx_rules.py
+++ b/test/rules/test_enginx_rules.py
@@ -50,8 +50,10 @@ def reset_enginx_run_number_cycle_map_cache():
 
 
 def test_enginx_group_rule_valid_values(job_request):
-    """Test that valid group values are accepted and set in
-    additional_values."""
+    """
+    Test that valid group values are accepted and set in
+    additional_values.
+    """
     valid_groups = ["both", "north", "south", "cropped", "custom", "texture20", "texture30"]
     for group in valid_groups:
         jr = job_request
@@ -77,8 +79,10 @@ def test_enginx_group_rule_invalid_value_raises(job_request):
     "rundetection.rules.enginx_rules.build_enginx_run_number_cycle_map", return_value={241391: "20_1", 299080: "20_1"}
 )
 def test_enginx_ceria_path_rule_finds_file(mock_map, run, expected_file, job_request, monkeypatch):
-    """Test that EnginxCeriaPathRule sets ceria_run and ceria_path when file
-    exists."""
+    """
+    Test that EnginxCeriaPathRule sets ceria_run and ceria_path when file
+    exists.
+    """
     # Point the root to test data
     monkeypatch.setattr(EnginxBasePathRule, "_ROOT", Path("test/test_data/e2e_data/NDXENGINX/Instrument/data"))
 
@@ -93,8 +97,10 @@ def test_enginx_ceria_path_rule_finds_file(mock_map, run, expected_file, job_req
 
 @patch("rundetection.rules.enginx_rules.build_enginx_run_number_cycle_map", return_value={241391: "20_1"})
 def test_enginx_vanadium_path_rule_finds_file(mock_map, job_request, monkeypatch):
-    """Test that EnginxVanadiumPathRule sets the vanadium path when the file
-    exists."""
+    """
+    Test that EnginxVanadiumPathRule sets the vanadium path when the file
+    exists.
+    """
     monkeypatch.setattr(EnginxBasePathRule, "_ROOT", Path("test/test_data/e2e_data/NDXENGINX/Instrument/data"))
     rule = EnginxVanadiumPathRule(241391)
     rule.verify(job_request)
@@ -103,8 +109,10 @@ def test_enginx_vanadium_path_rule_finds_file(mock_map, job_request, monkeypatch
 
 
 def test_enginx_path_rule_not_found(job_request, monkeypatch):
-    """If run cannot be found, no exception and no path_key set, but ceria_run
-    still set."""
+    """
+    If run cannot be found, no exception and no path_key set, but ceria_run
+    still set.
+    """
     # Ensure latest cycle dir points to test data but run is missing
     monkeypatch.setattr(EnginxBasePathRule, "_ROOT", Path("test/test_data/e2e_data/NDXENGINX/Instrument/data"))
 
@@ -138,8 +146,10 @@ def test_coerce_run_invalid_raises():
 @patch("rundetection.rules.enginx_rules.cache_set_json")
 @patch("rundetection.rules.enginx_rules.cache_get_json", return_value={"241391": "20_1"})
 def test_build_enginx_run_number_cycle_map_uses_cached_mapping(mock_cache_get, mock_cache_set):
-    """Cached JSON mapping is returned with run numbers coerced back to
-    ints."""
+    """
+    Cached JSON mapping is returned with run numbers coerced back to
+    ints.
+    """
     assert build_enginx_run_number_cycle_map() == {241391: "20_1"}
     mock_cache_get.assert_called_once_with(ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY)
     mock_cache_set.assert_not_called()
@@ -192,8 +202,10 @@ def test_read_enginx_run_number_cycle_map_warns_when_journal_dir_missing(
     tmp_path,
     caplog: pytest.LogCaptureFixture,
 ):
-    """Missing journal directories return an empty mapping with a clear
-    warning."""
+    """
+    Missing journal directories return an empty mapping with a clear
+    warning.
+    """
     caplog.set_level(logging.WARNING)
     journal_dir = tmp_path / "missing"
 
@@ -220,8 +232,10 @@ def test_read_enginx_run_number_cycle_map_warns_when_no_xml_files_found(
     tmp_path,
     caplog: pytest.LogCaptureFixture,
 ):
-    """Empty journal directories return an empty mapping with a clear
-    warning."""
+    """
+    Empty journal directories return an empty mapping with a clear
+    warning.
+    """
     caplog.set_level(logging.WARNING)
 
     assert _read_enginx_run_number_cycle_map(tmp_path) == {}

--- a/test/rules/test_enginx_rules.py
+++ b/test/rules/test_enginx_rules.py
@@ -24,7 +24,10 @@ REPEATED_BUILD_CALL_COUNT = 2
 
 @pytest.fixture
 def job_request():
-    """Job request fixture :return: job request."""
+    """
+    Job request fixture
+    :return: job request.
+    """
     return JobRequest(
         run_number=100,
         filepath=Path("/archive/100/ENGINX100.nxs"),
@@ -50,10 +53,7 @@ def reset_enginx_run_number_cycle_map_cache():
 
 
 def test_enginx_group_rule_valid_values(job_request):
-    """
-    Test that valid group values are accepted and set in
-    additional_values.
-    """
+    """Test that valid group values are accepted and set in additional_values."""
     valid_groups = ["both", "north", "south", "cropped", "custom", "texture20", "texture30"]
     for group in valid_groups:
         jr = job_request
@@ -79,10 +79,7 @@ def test_enginx_group_rule_invalid_value_raises(job_request):
     "rundetection.rules.enginx_rules.build_enginx_run_number_cycle_map", return_value={241391: "20_1", 299080: "20_1"}
 )
 def test_enginx_ceria_path_rule_finds_file(mock_map, run, expected_file, job_request, monkeypatch):
-    """
-    Test that EnginxCeriaPathRule sets ceria_run and ceria_path when file
-    exists.
-    """
+    """Test that EnginxCeriaPathRule sets ceria_run and ceria_path when file exists."""
     # Point the root to test data
     monkeypatch.setattr(EnginxBasePathRule, "_ROOT", Path("test/test_data/e2e_data/NDXENGINX/Instrument/data"))
 
@@ -97,10 +94,7 @@ def test_enginx_ceria_path_rule_finds_file(mock_map, run, expected_file, job_req
 
 @patch("rundetection.rules.enginx_rules.build_enginx_run_number_cycle_map", return_value={241391: "20_1"})
 def test_enginx_vanadium_path_rule_finds_file(mock_map, job_request, monkeypatch):
-    """
-    Test that EnginxVanadiumPathRule sets the vanadium path when the file
-    exists.
-    """
+    """Test that EnginxVanadiumPathRule sets the vanadium path when the file exists."""
     monkeypatch.setattr(EnginxBasePathRule, "_ROOT", Path("test/test_data/e2e_data/NDXENGINX/Instrument/data"))
     rule = EnginxVanadiumPathRule(241391)
     rule.verify(job_request)
@@ -109,10 +103,7 @@ def test_enginx_vanadium_path_rule_finds_file(mock_map, job_request, monkeypatch
 
 
 def test_enginx_path_rule_not_found(job_request, monkeypatch):
-    """
-    If run cannot be found, no exception and no path_key set, but ceria_run
-    still set.
-    """
+    """If run cannot be found, no exception and no path_key set, but ceria_run still set."""
     # Ensure latest cycle dir points to test data but run is missing
     monkeypatch.setattr(EnginxBasePathRule, "_ROOT", Path("test/test_data/e2e_data/NDXENGINX/Instrument/data"))
 

--- a/test/rules/test_enginx_rules.py
+++ b/test/rules/test_enginx_rules.py
@@ -19,6 +19,8 @@ from rundetection.rules.enginx_rules import (
     build_enginx_run_number_cycle_map,
 )
 
+REPEATED_BUILD_CALL_COUNT = 2
+
 
 @pytest.fixture
 def job_request():
@@ -244,8 +246,8 @@ def test_build_enginx_run_number_cycle_map_does_not_cache_empty_mapping(
         assert build_enginx_run_number_cycle_map() == {}
         assert build_enginx_run_number_cycle_map() == {}
 
-    assert mock_read.call_count == 2
-    assert mock_cache_get.call_count == 2
+    assert mock_read.call_count == REPEATED_BUILD_CALL_COUNT
+    assert mock_cache_get.call_count == REPEATED_BUILD_CALL_COUNT
     mock_cache_set.assert_not_called()
 
 
@@ -300,5 +302,5 @@ def test_build_enginx_run_number_cycle_map_memoizes_journal_reads_after_valkey_m
         assert build_enginx_run_number_cycle_map()[241391] == "20_1"
 
     mock_read.assert_called_once()
-    assert mock_cache_get.call_count == 2
-    assert mock_cache_set.call_count == 2
+    assert mock_cache_get.call_count == REPEATED_BUILD_CALL_COUNT
+    assert mock_cache_set.call_count == REPEATED_BUILD_CALL_COUNT

--- a/test/rules/test_enginx_rules.py
+++ b/test/rules/test_enginx_rules.py
@@ -9,7 +9,7 @@ import pytest
 from rundetection.exceptions import RuleViolationError
 from rundetection.ingestion.ingest import JobRequest
 from rundetection.rules.enginx_rules import (
-    ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY,
+    ENGINX_CACHE_KEY,
     EnginxBasePathRule,
     EnginxCeriaPathRule,
     EnginxGroupRule,
@@ -151,7 +151,7 @@ def test_build_enginx_run_number_cycle_map_uses_cached_mapping(mock_cache_get, m
     ints.
     """
     assert build_enginx_run_number_cycle_map() == {241391: "20_1"}
-    mock_cache_get.assert_called_once_with(ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY)
+    mock_cache_get.assert_called_once_with(ENGINX_CACHE_KEY)
     mock_cache_set.assert_not_called()
 
 
@@ -173,8 +173,8 @@ def test_build_enginx_run_number_cycle_map_reads_journals_and_populates_cache(
 
     assert mapping[241391] == "20_1"
     assert mapping[299080] == "20_1"
-    mock_cache_get.assert_called_once_with(ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY)
-    mock_cache_set.assert_called_once_with(ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY, mapping, 123)
+    mock_cache_get.assert_called_once_with(ENGINX_CACHE_KEY)
+    mock_cache_set.assert_called_once_with(ENGINX_CACHE_KEY, mapping, 123)
 
 
 @patch("rundetection.rules.enginx_rules.cache_set_json")

--- a/test/rules/test_enginx_rules.py
+++ b/test/rules/test_enginx_rules.py
@@ -16,6 +16,7 @@ from rundetection.rules.enginx_rules import (
     EnginxVanadiumPathRule,
     _clear_enginx_run_number_cycle_map_cache,
     _read_enginx_run_number_cycle_map,
+    _walk_enginx_journal_node,
     build_enginx_run_number_cycle_map,
 )
 
@@ -132,6 +133,21 @@ def test_coerce_run_invalid_raises():
     """Test that invalid run raises an exception."""
     with pytest.raises(ValueError):  # noqa: PT011
         EnginxBasePathRule._coerce_run("no-digits")
+
+
+def test_walk_enginx_journal_node_continues_after_malformed_enginx_name():
+    """Malformed EnginX entry names should not hide valid nested runs."""
+    mapping: dict[int, str] = {}
+    node = {
+        "@name": "ENGINX",
+        "children": {
+            "@name": "ENGINX241391",
+        },
+    }
+
+    _walk_enginx_journal_node(node, "journal_20_1", mapping)
+
+    assert mapping == {241391: "20_1"}
 
 
 @patch("rundetection.rules.enginx_rules.cache_set_json")
@@ -286,12 +302,12 @@ def test_build_enginx_run_number_cycle_map_reads_journals_when_ttl_disabled(
 
 @patch("rundetection.rules.enginx_rules.cache_set_json")
 @patch("rundetection.rules.enginx_rules.cache_get_json", return_value=None)
-def test_build_enginx_run_number_cycle_map_memoizes_journal_reads_after_valkey_miss(
+def test_build_enginx_run_number_cycle_map_reuses_local_cache_after_valkey_miss(
     mock_cache_get,
     mock_cache_set,
     monkeypatch,
 ):
-    """Repeated Valkey misses reuse the in-process journal mapping."""
+    """Repeated calls reuse the in-process journal mapping before Valkey."""
     monkeypatch.setenv(
         "ENGINX_JOURNAL_DIR",
         "test/test_data/e2e_data/NDXENGINX/Instrument/logs/journal",
@@ -306,8 +322,8 @@ def test_build_enginx_run_number_cycle_map_memoizes_journal_reads_after_valkey_m
         assert build_enginx_run_number_cycle_map()[241391] == "20_1"
 
     mock_read.assert_called_once()
-    assert mock_cache_get.call_count == REPEATED_BUILD_CALL_COUNT
-    assert mock_cache_set.call_count == REPEATED_BUILD_CALL_COUNT
+    mock_cache_get.assert_called_once_with(ENGINX_CACHE_KEY)
+    mock_cache_set.assert_called_once()
 
 
 @patch("rundetection.rules.enginx_rules.cache_set_json")

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -1,0 +1,86 @@
+"""Tests for Valkey cache helpers."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from valkey.exceptions import ValkeyError
+
+from rundetection.cache import _valkey_state, cache_get_json, cache_set_json, get_valkey_client
+
+
+@pytest.fixture(autouse=True)
+def reset_valkey_state():
+    """Clear the shared Valkey state around each test."""
+    _valkey_state.cache_clear()
+    yield
+    _valkey_state.cache_clear()
+
+
+def test_get_valkey_client_uses_configured_url():
+    """The client is created from VALKEY_URL with short timeouts."""
+    with (
+        patch.dict(os.environ, {"VALKEY_URL": "redis://localhost:6379/0"}),
+        patch("rundetection.cache.Valkey.from_url") as mock_from_url,
+    ):
+        assert get_valkey_client() == mock_from_url.return_value
+
+    mock_from_url.assert_called_once_with(
+        "redis://localhost:6379/0",
+        decode_responses=True,
+        socket_connect_timeout=0.5,
+        socket_timeout=1,
+        retry_on_timeout=False,
+    )
+
+
+def test_get_valkey_client_disables_cache_after_connection_error():
+    """A connection error disables further Valkey client creation attempts."""
+    with patch("rundetection.cache.Valkey.from_url", side_effect=ValkeyError("boom")) as mock_from_url:
+        assert get_valkey_client() is None
+        assert get_valkey_client() is None
+
+    mock_from_url.assert_called_once()
+
+
+def test_cache_get_json_returns_parsed_payload():
+    """JSON cache values are deserialized before being returned."""
+    mock_client = MagicMock()
+    mock_client.get.return_value = '{"answer": 42}'
+
+    with patch("rundetection.cache.get_valkey_client", return_value=mock_client):
+        assert cache_get_json("key") == {"answer": 42}
+
+
+def test_cache_get_json_disables_cache_on_valkey_error():
+    """Valkey read errors disable the shared cache."""
+    mock_client = MagicMock()
+    mock_client.get.side_effect = ValkeyError("boom")
+
+    with (
+        patch("rundetection.cache.get_valkey_client", return_value=mock_client),
+        patch("rundetection.cache._disable_cache") as mock_disable,
+    ):
+        assert cache_get_json("key") is None
+
+    mock_disable.assert_called_once()
+
+
+def test_cache_set_json_sets_payload_with_ttl():
+    """JSON-serializable values are stored using the given TTL."""
+    mock_client = MagicMock()
+
+    with patch("rundetection.cache.get_valkey_client", return_value=mock_client):
+        cache_set_json("key", {"answer": 42}, 60)
+
+    mock_client.setex.assert_called_once_with("key", 60, '{"answer": 42}')
+
+
+def test_cache_set_json_ignores_non_positive_ttl():
+    """Non-positive TTLs skip cache writes before creating a client."""
+    with patch("rundetection.cache.get_valkey_client") as mock_get_client:
+        cache_set_json("key", {"answer": 42}, 0)
+
+    mock_get_client.assert_not_called()

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -112,8 +112,10 @@ def test_cache_set_json_sets_payload_with_ttl():
 
 
 def test_cache_set_json_logs_and_disables_cache_on_valkey_error(caplog: pytest.LogCaptureFixture):
-    """Valkey write errors are logged with key context before graceful
-    fallback."""
+    """
+    Valkey write errors are logged with key context before graceful
+    fallback.
+    """
     caplog.set_level(logging.ERROR)
     mock_client = MagicMock()
     mock_client.setex.side_effect = ValkeyError("boom")

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from valkey.exceptions import ValkeyError
 
-from rundetection.cache import _disable_cache, _valkey_state, cache_get_json, cache_set_json, get_valkey_client
+from rundetection.cache import _valkey_state, cache_get_json, cache_set_json, get_valkey_client
 
 
 @pytest.fixture(autouse=True)
@@ -23,7 +23,7 @@ def reset_valkey_state():
 def test_get_valkey_client_uses_configured_url():
     """The client is created from VALKEY_URL with short timeouts."""
     with (
-        patch.dict(os.environ, {"VALKEY_URL": "redis://localhost:6379/0"}),
+        patch.dict(os.environ, {"VALKEY_URL": "redis://localhost:6379/0", "VALKEY_CACHE_ENABLED": "true"}),
         patch("rundetection.cache.Valkey.from_url") as mock_from_url,
     ):
         assert get_valkey_client() == mock_from_url.return_value
@@ -37,6 +37,17 @@ def test_get_valkey_client_uses_configured_url():
     )
 
 
+def test_get_valkey_client_returns_none_when_cache_disabled():
+    """VALKEY_CACHE_ENABLED=false opts out of Valkey client creation."""
+    with (
+        patch.dict(os.environ, {"VALKEY_CACHE_ENABLED": "false"}),
+        patch("rundetection.cache.Valkey.from_url") as mock_from_url,
+    ):
+        assert get_valkey_client() is None
+
+    mock_from_url.assert_not_called()
+
+
 def test_get_valkey_client_disables_cache_after_connection_error(caplog: pytest.LogCaptureFixture):
     """A connection error disables further Valkey client creation attempts."""
     caplog.set_level(logging.WARNING)
@@ -46,7 +57,7 @@ def test_get_valkey_client_disables_cache_after_connection_error(caplog: pytest.
         assert get_valkey_client() is None
 
     mock_from_url.assert_called_once()
-    assert [record.message for record in caplog.records] == ["Valkey cache disabled: boom"]
+    assert "Valkey cache disabled: boom" in caplog.text
 
 
 def test_cache_get_json_returns_parsed_payload():
@@ -58,46 +69,48 @@ def test_cache_get_json_returns_parsed_payload():
         assert cache_get_json("key") == {"answer": 42}
 
 
-def test_cache_get_json_disables_cache_on_valkey_error(caplog: pytest.LogCaptureFixture):
-    """Valkey read errors disable the shared cache."""
-    caplog.set_level(logging.ERROR)
+def test_cache_get_json_logs_closes_and_returns_none_on_valkey_error(caplog: pytest.LogCaptureFixture):
+    """Valkey read errors are logged and treated as cache misses."""
+    caplog.set_level(logging.WARNING)
     mock_client = MagicMock()
     mock_client.get.side_effect = ValkeyError("boom")
 
     with (
-        patch("rundetection.cache.get_valkey_client", return_value=mock_client),
-        patch("rundetection.cache._disable_cache") as mock_disable,
+        patch.dict(os.environ, {"VALKEY_URL": "redis://localhost:6379/0", "VALKEY_CACHE_ENABLED": "true"}),
+        patch("rundetection.cache.Valkey.from_url", return_value=mock_client),
     ):
         assert cache_get_json("key") is None
 
-    mock_disable.assert_called_once()
-    assert "Failed to retrieve JSON from Valkey cache for key: key" in caplog.text
-
-
-def test_disable_cache_closes_existing_client():
-    """Disabling the cache closes and releases an existing Valkey client."""
-    state = _valkey_state()
-    mock_client = MagicMock()
-    state.client = mock_client
-
-    _disable_cache(ValkeyError("boom"))
-
-    assert state.disabled is True
-    assert state.client is None
+    assert _valkey_state().client is None
+    assert _valkey_state().disabled is True
     mock_client.close.assert_called_once()
+    assert "Failed to retrieve JSON from Valkey cache for key key: boom" in caplog.text
 
 
-def test_disable_cache_suppresses_client_close_errors():
-    """Client cleanup failures should not escape the cache disable path."""
-    state = _valkey_state()
+def test_cache_get_json_skips_client_when_cache_disabled():
+    """Disabled Valkey caching returns no cached value without connecting."""
+    with (
+        patch.dict(os.environ, {"VALKEY_CACHE_ENABLED": "off"}),
+        patch("rundetection.cache.Valkey.from_url") as mock_from_url,
+    ):
+        assert cache_get_json("key") is None
+
+    mock_from_url.assert_not_called()
+
+
+def test_cache_get_json_suppresses_client_close_errors_on_valkey_error():
+    """Client cleanup failures should not escape the cache read path."""
     mock_client = MagicMock()
+    mock_client.get.side_effect = ValkeyError("boom")
     mock_client.close.side_effect = RuntimeError("close failed")
-    state.client = mock_client
 
-    _disable_cache(ValkeyError("boom"))
+    with (
+        patch.dict(os.environ, {"VALKEY_URL": "redis://localhost:6379/0", "VALKEY_CACHE_ENABLED": "true"}),
+        patch("rundetection.cache.Valkey.from_url", return_value=mock_client),
+    ):
+        assert cache_get_json("key") is None
 
-    assert state.disabled is True
-    assert state.client is None
+    assert _valkey_state().client is None
     mock_client.close.assert_called_once()
 
 
@@ -111,23 +124,22 @@ def test_cache_set_json_sets_payload_with_ttl():
     mock_client.setex.assert_called_once_with("key", 60, '{"answer": 42}')
 
 
-def test_cache_set_json_logs_and_disables_cache_on_valkey_error(caplog: pytest.LogCaptureFixture):
-    """
-    Valkey write errors are logged with key context before graceful
-    fallback.
-    """
-    caplog.set_level(logging.ERROR)
+def test_cache_set_json_logs_closes_and_returns_on_valkey_error(caplog: pytest.LogCaptureFixture):
+    """Valkey write errors are logged with key context and ignored."""
+    caplog.set_level(logging.WARNING)
     mock_client = MagicMock()
     mock_client.setex.side_effect = ValkeyError("boom")
 
     with (
-        patch("rundetection.cache.get_valkey_client", return_value=mock_client),
-        patch("rundetection.cache._disable_cache") as mock_disable,
+        patch.dict(os.environ, {"VALKEY_URL": "redis://localhost:6379/0", "VALKEY_CACHE_ENABLED": "true"}),
+        patch("rundetection.cache.Valkey.from_url", return_value=mock_client),
     ):
         cache_set_json("key", {"answer": 42}, 60)
 
-    mock_disable.assert_called_once()
-    assert "Failed to store JSON in Valkey cache for key: key" in caplog.text
+    assert _valkey_state().client is None
+    assert _valkey_state().disabled is True
+    mock_client.close.assert_called_once()
+    assert "Failed to store JSON in Valkey cache for key key: boom" in caplog.text
 
 
 def test_cache_set_json_ignores_non_positive_ttl():

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from unittest.mock import MagicMock, patch
 
 import pytest
 from valkey.exceptions import ValkeyError
 
-from rundetection.cache import _valkey_state, cache_get_json, cache_set_json, get_valkey_client
+from rundetection.cache import _disable_cache, _valkey_state, cache_get_json, cache_set_json, get_valkey_client
 
 
 @pytest.fixture(autouse=True)
@@ -36,13 +37,16 @@ def test_get_valkey_client_uses_configured_url():
     )
 
 
-def test_get_valkey_client_disables_cache_after_connection_error():
+def test_get_valkey_client_disables_cache_after_connection_error(caplog: pytest.LogCaptureFixture):
     """A connection error disables further Valkey client creation attempts."""
+    caplog.set_level(logging.WARNING)
+
     with patch("rundetection.cache.Valkey.from_url", side_effect=ValkeyError("boom")) as mock_from_url:
         assert get_valkey_client() is None
         assert get_valkey_client() is None
 
     mock_from_url.assert_called_once()
+    assert [record.message for record in caplog.records] == ["Valkey cache disabled: boom"]
 
 
 def test_cache_get_json_returns_parsed_payload():
@@ -54,8 +58,9 @@ def test_cache_get_json_returns_parsed_payload():
         assert cache_get_json("key") == {"answer": 42}
 
 
-def test_cache_get_json_disables_cache_on_valkey_error():
+def test_cache_get_json_disables_cache_on_valkey_error(caplog: pytest.LogCaptureFixture):
     """Valkey read errors disable the shared cache."""
+    caplog.set_level(logging.ERROR)
     mock_client = MagicMock()
     mock_client.get.side_effect = ValkeyError("boom")
 
@@ -66,6 +71,34 @@ def test_cache_get_json_disables_cache_on_valkey_error():
         assert cache_get_json("key") is None
 
     mock_disable.assert_called_once()
+    assert "Failed to retrieve JSON from Valkey cache for key: key" in caplog.text
+
+
+def test_disable_cache_closes_existing_client():
+    """Disabling the cache closes and releases an existing Valkey client."""
+    state = _valkey_state()
+    mock_client = MagicMock()
+    state.client = mock_client
+
+    _disable_cache(ValkeyError("boom"))
+
+    assert state.disabled is True
+    assert state.client is None
+    mock_client.close.assert_called_once()
+
+
+def test_disable_cache_suppresses_client_close_errors():
+    """Client cleanup failures should not escape the cache disable path."""
+    state = _valkey_state()
+    mock_client = MagicMock()
+    mock_client.close.side_effect = RuntimeError("close failed")
+    state.client = mock_client
+
+    _disable_cache(ValkeyError("boom"))
+
+    assert state.disabled is True
+    assert state.client is None
+    mock_client.close.assert_called_once()
 
 
 def test_cache_set_json_sets_payload_with_ttl():
@@ -76,6 +109,23 @@ def test_cache_set_json_sets_payload_with_ttl():
         cache_set_json("key", {"answer": 42}, 60)
 
     mock_client.setex.assert_called_once_with("key", 60, '{"answer": 42}')
+
+
+def test_cache_set_json_logs_and_disables_cache_on_valkey_error(caplog: pytest.LogCaptureFixture):
+    """Valkey write errors are logged with key context before graceful
+    fallback."""
+    caplog.set_level(logging.ERROR)
+    mock_client = MagicMock()
+    mock_client.setex.side_effect = ValkeyError("boom")
+
+    with (
+        patch("rundetection.cache.get_valkey_client", return_value=mock_client),
+        patch("rundetection.cache._disable_cache") as mock_disable,
+    ):
+        cache_set_json("key", {"answer": 42}, 60)
+
+    mock_disable.assert_called_once()
+    assert "Failed to store JSON in Valkey cache for key: key" in caplog.text
 
 
 def test_cache_set_json_ignores_non_positive_ttl():

--- a/test/test_data/e2e_data/NDXENGINX/Instrument/logs/journal/journal_21_1.xml
+++ b/test/test_data/e2e_data/NDXENGINX/Instrument/logs/journal/journal_21_1.xml
@@ -1,0 +1,281 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<NXroot NeXus_version="4.3.0" XML_version="mxml"
+        file_name="c:\data\journal_20_2.xml"
+        xmlns="http://definition.nexusformat.org/schema/3.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://definition.nexusformat.org/schema/3.0"
+        file_time="2020-09-10T10:33:14+00:00">
+    <NXentry name="ENGINX00324668">
+        <title NAPItype="NX_CHAR[14]">Some Title</title>
+        <simulation_mode NAPItype="NX_CHAR[2]">NO</simulation_mode>
+        <user_name NAPItype="NX_CHAR[11]">UNSPECIFIED</user_name>
+        <local_contact NAPItype="NX_CHAR[11]">UNSPECIFIED</local_contact>
+        <user_institute NAPItype="NX_CHAR[11]">UNSPECIFIED</user_institute>
+        <experiment_identifier NAPItype="NX_CHAR[1]">0</experiment_identifier>
+        <instrument_name NAPItype="NX_CHAR[6]">ENGINX</instrument_name>
+        <run_number NAPItype="NX_INT32">324667
+        </run_number>
+        <sample_id NAPItype="NX_CHAR[2]">0
+        </sample_id>
+        <measurement_first_run NAPItype="NX_INT32">0
+        </measurement_first_run>
+        <measurement_id NAPItype="NX_CHAR[2]">0
+        </measurement_id>
+        <measurement_label NAPItype="NX_CHAR[11]">UNSPECIFIED</measurement_label>
+        <measurement_type NAPItype="NX_CHAR[2]">0
+        </measurement_type>
+        <measurement_subid NAPItype="NX_CHAR[2]">0
+        </measurement_subid>
+        <start_time NAPItype="NX_CHAR[19]">2020-09-10T10:33:00</start_time>
+        <end_time NAPItype="NX_CHAR[19]">2020-09-10T10:33:11</end_time>
+        <duration NAPItype="NX_INT64">11
+        </duration>
+        <proton_charge NAPItype="NX_FLOAT32">1.2
+        </proton_charge>
+        <raw_frames NAPItype="NX_UINT32">32
+        </raw_frames>
+        <good_frames NAPItype="NX_UINT32">32
+        </good_frames>
+        <number_periods NAPItype="NX_INT32">32
+        </number_periods>
+        <number_spectra NAPItype="NX_INT32">32
+        </number_spectra>
+        <number_detectors NAPItype="NX_INT32">32
+        </number_detectors>
+        <number_time_regimes NAPItype="NX_INT32">32
+        </number_time_regimes>
+        <frame_sync NAPItype="NX_CHAR[3]">LOL</frame_sync>
+        <IXtime_regime name="time_regime_1">
+            <number_time_channels NAPItype="NX_INT32">12
+            </number_time_channels>
+            <time_channel_min NAPItype="NX_FLOAT32">9000.0000
+            </time_channel_min>
+            <time_channel_max NAPItype="NX_FLOAT32">999.0000
+            </time_channel_max>
+        </IXtime_regime>
+        <IXtime_regime name="time_regime_2">
+            <number_time_channels NAPItype="NX_INT32">402
+            </number_time_channels>
+            <time_channel_min NAPItype="NX_FLOAT32">4200.0000
+            </time_channel_min>
+            <time_channel_max NAPItype="NX_FLOAT32">4100.0000
+            </time_channel_max>
+        </IXtime_regime>
+        <icp_version NAPItype="NX_CHAR[79]">Super Secret ICP Version</icp_version>
+        <detector_table_file NAPItype="NX_CHAR[97]">wow a transdet table</detector_table_file>
+        <spectra_table_file NAPItype="NX_CHAR[91]">wow a transdet spectra</spectra_table_file>
+        <wiring_table_file NAPItype="NX_CHAR[83]">ahhhh wireeee</wiring_table_file>
+        <monitor_spectrum NAPItype="NX_INT32">12
+        </monitor_spectrum>
+        <monitor_sum NAPItype="NX_UINT32">3
+        </monitor_sum>
+        <total_mevents NAPItype="NX_FLOAT32">1.23
+        </total_mevents>
+        <comment NAPItype="NX_CHAR[11]">UNSPECIFIED</comment>
+        <field_label NAPItype="NX_CHAR[11]">UNSPECIFIED</field_label>
+        <instrument_geometry NAPItype="NX_CHAR[11]">UNSPECIFIED</instrument_geometry>
+        <script_name NAPItype="NX_CHAR[2]">0
+        </script_name>
+        <sample_name NAPItype="NX_CHAR[2]">0
+        </sample_name>
+        <sample_orientation NAPItype="NX_CHAR[2]">0
+        </sample_orientation>
+        <temperature_label NAPItype="NX_CHAR[11]">UNSPECIFIED</temperature_label>
+        <npratio_average NAPItype="NX_FLOAT32">0.0000
+        </npratio_average>
+        <isis_cycle NAPItype="NX_CHAR[4]">20_2</isis_cycle>
+        <seci_config NAPItype="NX_CHAR[17]">based cyberman</seci_config>
+        <event_mode NAPItype="NX_FLOAT64">0.00000
+        </event_mode>
+        <IXselog name="selog">
+            <IXseblock name="0
+">
+                <current_value NAPItype="NX_CHAR[3]">gran</current_value>
+                <setpoint_value NAPItype="NX_CHAR[3]">nan</setpoint_value>
+                <average_value NAPItype="NX_CHAR[3]">man</average_value>
+            </IXseblock>
+        </IXselog>
+    </NXentry>
+    <NXentry name="ENGINX00241392">
+        <title NAPItype="NX_CHAR[14]">Sir</title>
+        <simulation_mode NAPItype="NX_CHAR[2]">YES</simulation_mode>
+        <user_name NAPItype="NX_CHAR[11]">UNS</user_name>
+        <local_contact NAPItype="NX_CHAR[11]">UNSPECIFIED</local_contact>
+        <user_institute NAPItype="NX_CHAR[11]">UNSPECIFIED</user_institute>
+        <experiment_identifier NAPItype="NX_CHAR[1]">0</experiment_identifier>
+        <instrument_name NAPItype="NX_CHAR[6]">ENGINX</instrument_name>
+        <run_number NAPItype="NX_INT32">2131
+        </run_number>
+        <sample_id NAPItype="NX_CHAR[2]">123
+        </sample_id>
+        <measurement_first_run NAPItype="NX_INT32">123
+        </measurement_first_run>
+        <measurement_id NAPItype="NX_CHAR[2]">123
+        </measurement_id>
+        <measurement_label NAPItype="NX_CHAR[11]">ECIFIED</measurement_label>
+        <measurement_type NAPItype="NX_CHAR[2]">1231
+        </measurement_type>
+        <measurement_subid NAPItype="NX_CHAR[2]">1231231
+        </measurement_subid>
+        <start_time NAPItype="NX_CHAR[19]">2020-09-10T10:33:22</start_time>
+        <end_time NAPItype="NX_CHAR[19]">2020-09-10T10:33:30</end_time>
+        <duration NAPItype="NX_INT64">1231
+        </duration>
+        <proton_charge NAPItype="NX_FLOAT32">0.432131234784
+        </proton_charge>
+        <raw_frames NAPItype="NX_UINT32">41231
+        </raw_frames>
+        <good_frames NAPItype="NX_UINT32">4534
+        </good_frames>
+        <number_periods NAPItype="NX_INT32">76575
+        </number_periods>
+        <number_spectra NAPItype="NX_INT32">342
+        </number_spectra>
+        <number_detectors NAPItype="NX_INT32">2342
+        </number_detectors>
+        <number_time_regimes NAPItype="NX_INT32">3242
+        </number_time_regimes>
+        <frame_sync NAPItype="NX_CHAR[16]">wow</frame_sync>
+        <IXtime_regime name="time_regime_1">
+            <number_time_channels NAPItype="NX_INT32">1321231
+            </number_time_channels>
+            <time_channel_min NAPItype="NX_FLOAT32">32131
+            </time_channel_min>
+            <time_channel_max NAPItype="NX_FLOAT32">464563
+            </time_channel_max>
+        </IXtime_regime>
+        <IXtime_regime name="time_regime_2">
+            <number_time_channels NAPItype="NX_INT32">2352
+            </number_time_channels>
+            <time_channel_min NAPItype="NX_FLOAT32">603400.0000
+            </time_channel_min>
+            <time_channel_max NAPItype="NX_FLOAT32">4604320.0000
+            </time_channel_max>
+        </IXtime_regime>
+        <icp_version NAPItype="NX_CHAR[79]">SMi</icp_version>
+        <detector_table_file NAPItype="NX_CHAR[97]">The quick brown fox</detector_table_file>
+        <spectra_table_file NAPItype="NX_CHAR[91]">jumps over the</spectra_table_file>
+        <wiring_table_file NAPItype="NX_CHAR[83]">lazy dog</wiring_table_file>
+        <monitor_spectrum NAPItype="NX_INT32">3422
+        </monitor_spectrum>
+        <monitor_sum NAPItype="NX_UINT32">342
+        </monitor_sum>
+        <total_mevents NAPItype="NX_FLOAT32">4234.1231
+        </total_mevents>
+        <comment NAPItype="NX_CHAR[11]">UNSPECIFIED</comment>
+        <field_label NAPItype="NX_CHAR[11]">UNSPECIFIED</field_label>
+        <instrument_geometry NAPItype="NX_CHAR[11]">UNSPECIFIED</instrument_geometry>
+        <script_name NAPItype="NX_CHAR[2]">1
+        </script_name>
+        <sample_name NAPItype="NX_CHAR[2]">1
+        </sample_name>
+        <sample_orientation NAPItype="NX_CHAR[2]">2
+        </sample_orientation>
+        <temperature_label NAPItype="NX_CHAR[11]">UNSPECIFIED</temperature_label>
+        <npratio_average NAPItype="NX_FLOAT32">31.0000
+        </npratio_average>
+        <isis_cycle NAPItype="NX_CHAR[4]">20_1</isis_cycle>
+        <seci_config NAPItype="NX_CHAR[17]">Based cyberman</seci_config>
+        <event_mode NAPItype="NX_FLOAT64">0.2300000
+        </event_mode>
+        <IXselog name="selog">
+            <IXseblock name="0
+">
+                <current_value NAPItype="NX_CHAR[3]">lol</current_value>
+                <setpoint_value NAPItype="NX_CHAR[3]">wtf</setpoint_value>
+                <average_value NAPItype="NX_CHAR[3]">m8</average_value>
+            </IXseblock>
+        </IXselog>
+    </NXentry>
+    <NXentry name="ENGINX00299083">
+        <title NAPItype="NX_CHAR[15]">Hello world</title>
+        <simulation_mode NAPItype="NX_CHAR[2]">NO</simulation_mode>
+        <user_name NAPItype="NX_CHAR[9]">kdslfs</user_name>
+        <local_contact NAPItype="NX_CHAR[11]">UNSPECIFIED</local_contact>
+        <user_institute NAPItype="NX_CHAR[11]">UNSPECIFIED</user_institute>
+        <experiment_identifier NAPItype="NX_CHAR[7]">21231</experiment_identifier>
+        <instrument_name NAPItype="NX_CHAR[6]">ENGINX</instrument_name>
+        <run_number NAPItype="NX_INT32">31231
+        </run_number>
+        <sample_id NAPItype="NX_CHAR[2]">321
+        </sample_id>
+        <measurement_first_run NAPItype="NX_INT32">31231
+        </measurement_first_run>
+        <measurement_id NAPItype="NX_CHAR[2]">31231
+        </measurement_id>
+        <measurement_label NAPItype="NX_CHAR[11]">UNSPECIFIED</measurement_label>
+        <measurement_type NAPItype="NX_CHAR[2]">0
+        </measurement_type>
+        <measurement_subid NAPItype="NX_CHAR[2]">0
+        </measurement_subid>
+        <start_time NAPItype="NX_CHAR[19]">2020-11-10T14:14:06</start_time>
+        <end_time NAPItype="NX_CHAR[19]">2020-11-10T14:14:12</end_time>
+        <duration NAPItype="NX_INT64">32131
+        </duration>
+        <proton_charge NAPItype="NX_FLOAT32">0.170923
+        </proton_charge>
+        <raw_frames NAPItype="NX_UINT32">231231
+        </raw_frames>
+        <good_frames NAPItype="NX_UINT32">31231
+        </good_frames>
+        <number_periods NAPItype="NX_INT32">3213
+        </number_periods>
+        <number_spectra NAPItype="NX_INT32">543
+        </number_spectra>
+        <number_detectors NAPItype="NX_INT32">523
+        </number_detectors>
+        <number_time_regimes NAPItype="NX_INT32">2
+        </number_time_regimes>
+        <frame_sync NAPItype="NX_CHAR[3]">Sok</frame_sync>
+        <IXtime_regime name="time_regime_1">
+            <number_time_channels NAPItype="NX_INT32">342342
+            </number_time_channels>
+            <time_channel_min NAPItype="NX_FLOAT32">432000.0000
+            </time_channel_min>
+            <time_channel_max NAPItype="NX_FLOAT32">43299.0000
+            </time_channel_max>
+        </IXtime_regime>
+        <IXtime_regime name="time_regime_2">
+            <number_time_channels NAPItype="NX_INT32">423420
+            </number_time_channels>
+            <time_channel_min NAPItype="NX_FLOAT32">6043200.0000
+            </time_channel_min>
+            <time_channel_max NAPItype="NX_FLOAT32">4604300.0000
+            </time_channel_max>
+        </IXtime_regime>
+        <icp_version NAPItype="NX_CHAR[79]">332sdasdasd</icp_version>
+        <detector_table_file NAPItype="NX_CHAR[97]">dsada</detector_table_file>
+        <spectra_table_file NAPItype="NX_CHAR[91]">sdada</spectra_table_file>
+        <wiring_table_file NAPItype="NX_CHAR[83]">sdada</wiring_table_file>
+        <monitor_spectrum NAPItype="NX_INT32">23423
+        </monitor_spectrum>
+        <monitor_sum NAPItype="NX_UINT32">4232
+        </monitor_sum>
+        <total_mevents NAPItype="NX_FLOAT32">234.1231
+        </total_mevents>
+        <comment NAPItype="NX_CHAR[11]">UNSPECIFIED</comment>
+        <field_label NAPItype="NX_CHAR[11]">UNSPECIFIED</field_label>
+        <instrument_geometry NAPItype="NX_CHAR[11]">UNSPECIFIED</instrument_geometry>
+        <script_name NAPItype="NX_CHAR[2]">0
+        </script_name>
+        <sample_name NAPItype="NX_CHAR[2]">0
+        </sample_name>
+        <sample_orientation NAPItype="NX_CHAR[2]">0
+        </sample_orientation>
+        <temperature_label NAPItype="NX_CHAR[11]">UNSPECIFIED</temperature_label>
+        <npratio_average NAPItype="NX_FLOAT32">3.1415926
+        </npratio_average>
+        <isis_cycle NAPItype="NX_CHAR[4]">20_2</isis_cycle>
+        <seci_config NAPItype="NX_CHAR[17]">based cyberman</seci_config>
+        <event_mode NAPItype="NX_FLOAT64">323100000
+        </event_mode>
+        <IXselog name="selog">
+            <IXseblock name="0
+">
+                <current_value NAPItype="NX_CHAR[3]">kjl</current_value>
+                <setpoint_value NAPItype="NX_CHAR[3]">Nadsa</setpoint_value>
+                <average_value NAPItype="NX_CHAR[3]">Nasda</average_value>
+            </IXseblock>
+        </IXselog>
+    </NXentry>
+</NXroot>

--- a/test/test_data/e2e_data/NDXENGINX/Instrument/logs/journal/journal_22_1.xml
+++ b/test/test_data/e2e_data/NDXENGINX/Instrument/logs/journal/journal_22_1.xml
@@ -1,0 +1,281 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<NXroot NeXus_version="4.3.0" XML_version="mxml"
+        file_name="c:\data\journal_20_2.xml"
+        xmlns="http://definition.nexusformat.org/schema/3.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://definition.nexusformat.org/schema/3.0"
+        file_time="2020-09-10T10:33:14+00:00">
+    <NXentry name="ENGINX00324669">
+        <title NAPItype="NX_CHAR[14]">Some Title</title>
+        <simulation_mode NAPItype="NX_CHAR[2]">NO</simulation_mode>
+        <user_name NAPItype="NX_CHAR[11]">UNSPECIFIED</user_name>
+        <local_contact NAPItype="NX_CHAR[11]">UNSPECIFIED</local_contact>
+        <user_institute NAPItype="NX_CHAR[11]">UNSPECIFIED</user_institute>
+        <experiment_identifier NAPItype="NX_CHAR[1]">0</experiment_identifier>
+        <instrument_name NAPItype="NX_CHAR[6]">ENGINX</instrument_name>
+        <run_number NAPItype="NX_INT32">324667
+        </run_number>
+        <sample_id NAPItype="NX_CHAR[2]">0
+        </sample_id>
+        <measurement_first_run NAPItype="NX_INT32">0
+        </measurement_first_run>
+        <measurement_id NAPItype="NX_CHAR[2]">0
+        </measurement_id>
+        <measurement_label NAPItype="NX_CHAR[11]">UNSPECIFIED</measurement_label>
+        <measurement_type NAPItype="NX_CHAR[2]">0
+        </measurement_type>
+        <measurement_subid NAPItype="NX_CHAR[2]">0
+        </measurement_subid>
+        <start_time NAPItype="NX_CHAR[19]">2020-09-10T10:33:00</start_time>
+        <end_time NAPItype="NX_CHAR[19]">2020-09-10T10:33:11</end_time>
+        <duration NAPItype="NX_INT64">11
+        </duration>
+        <proton_charge NAPItype="NX_FLOAT32">1.2
+        </proton_charge>
+        <raw_frames NAPItype="NX_UINT32">32
+        </raw_frames>
+        <good_frames NAPItype="NX_UINT32">32
+        </good_frames>
+        <number_periods NAPItype="NX_INT32">32
+        </number_periods>
+        <number_spectra NAPItype="NX_INT32">32
+        </number_spectra>
+        <number_detectors NAPItype="NX_INT32">32
+        </number_detectors>
+        <number_time_regimes NAPItype="NX_INT32">32
+        </number_time_regimes>
+        <frame_sync NAPItype="NX_CHAR[3]">LOL</frame_sync>
+        <IXtime_regime name="time_regime_1">
+            <number_time_channels NAPItype="NX_INT32">12
+            </number_time_channels>
+            <time_channel_min NAPItype="NX_FLOAT32">9000.0000
+            </time_channel_min>
+            <time_channel_max NAPItype="NX_FLOAT32">999.0000
+            </time_channel_max>
+        </IXtime_regime>
+        <IXtime_regime name="time_regime_2">
+            <number_time_channels NAPItype="NX_INT32">402
+            </number_time_channels>
+            <time_channel_min NAPItype="NX_FLOAT32">4200.0000
+            </time_channel_min>
+            <time_channel_max NAPItype="NX_FLOAT32">4100.0000
+            </time_channel_max>
+        </IXtime_regime>
+        <icp_version NAPItype="NX_CHAR[79]">Super Secret ICP Version</icp_version>
+        <detector_table_file NAPItype="NX_CHAR[97]">wow a transdet table</detector_table_file>
+        <spectra_table_file NAPItype="NX_CHAR[91]">wow a transdet spectra</spectra_table_file>
+        <wiring_table_file NAPItype="NX_CHAR[83]">ahhhh wireeee</wiring_table_file>
+        <monitor_spectrum NAPItype="NX_INT32">12
+        </monitor_spectrum>
+        <monitor_sum NAPItype="NX_UINT32">3
+        </monitor_sum>
+        <total_mevents NAPItype="NX_FLOAT32">1.23
+        </total_mevents>
+        <comment NAPItype="NX_CHAR[11]">UNSPECIFIED</comment>
+        <field_label NAPItype="NX_CHAR[11]">UNSPECIFIED</field_label>
+        <instrument_geometry NAPItype="NX_CHAR[11]">UNSPECIFIED</instrument_geometry>
+        <script_name NAPItype="NX_CHAR[2]">0
+        </script_name>
+        <sample_name NAPItype="NX_CHAR[2]">0
+        </sample_name>
+        <sample_orientation NAPItype="NX_CHAR[2]">0
+        </sample_orientation>
+        <temperature_label NAPItype="NX_CHAR[11]">UNSPECIFIED</temperature_label>
+        <npratio_average NAPItype="NX_FLOAT32">0.0000
+        </npratio_average>
+        <isis_cycle NAPItype="NX_CHAR[4]">20_2</isis_cycle>
+        <seci_config NAPItype="NX_CHAR[17]">based cyberman</seci_config>
+        <event_mode NAPItype="NX_FLOAT64">0.00000
+        </event_mode>
+        <IXselog name="selog">
+            <IXseblock name="0
+">
+                <current_value NAPItype="NX_CHAR[3]">gran</current_value>
+                <setpoint_value NAPItype="NX_CHAR[3]">nan</setpoint_value>
+                <average_value NAPItype="NX_CHAR[3]">man</average_value>
+            </IXseblock>
+        </IXselog>
+    </NXentry>
+    <NXentry name="ENGINX00241396">
+        <title NAPItype="NX_CHAR[14]">Sir</title>
+        <simulation_mode NAPItype="NX_CHAR[2]">YES</simulation_mode>
+        <user_name NAPItype="NX_CHAR[11]">UNS</user_name>
+        <local_contact NAPItype="NX_CHAR[11]">UNSPECIFIED</local_contact>
+        <user_institute NAPItype="NX_CHAR[11]">UNSPECIFIED</user_institute>
+        <experiment_identifier NAPItype="NX_CHAR[1]">0</experiment_identifier>
+        <instrument_name NAPItype="NX_CHAR[6]">ENGINX</instrument_name>
+        <run_number NAPItype="NX_INT32">2131
+        </run_number>
+        <sample_id NAPItype="NX_CHAR[2]">123
+        </sample_id>
+        <measurement_first_run NAPItype="NX_INT32">123
+        </measurement_first_run>
+        <measurement_id NAPItype="NX_CHAR[2]">123
+        </measurement_id>
+        <measurement_label NAPItype="NX_CHAR[11]">ECIFIED</measurement_label>
+        <measurement_type NAPItype="NX_CHAR[2]">1231
+        </measurement_type>
+        <measurement_subid NAPItype="NX_CHAR[2]">1231231
+        </measurement_subid>
+        <start_time NAPItype="NX_CHAR[19]">2020-09-10T10:33:22</start_time>
+        <end_time NAPItype="NX_CHAR[19]">2020-09-10T10:33:30</end_time>
+        <duration NAPItype="NX_INT64">1231
+        </duration>
+        <proton_charge NAPItype="NX_FLOAT32">0.432131234784
+        </proton_charge>
+        <raw_frames NAPItype="NX_UINT32">41231
+        </raw_frames>
+        <good_frames NAPItype="NX_UINT32">4534
+        </good_frames>
+        <number_periods NAPItype="NX_INT32">76575
+        </number_periods>
+        <number_spectra NAPItype="NX_INT32">342
+        </number_spectra>
+        <number_detectors NAPItype="NX_INT32">2342
+        </number_detectors>
+        <number_time_regimes NAPItype="NX_INT32">3242
+        </number_time_regimes>
+        <frame_sync NAPItype="NX_CHAR[16]">wow</frame_sync>
+        <IXtime_regime name="time_regime_1">
+            <number_time_channels NAPItype="NX_INT32">1321231
+            </number_time_channels>
+            <time_channel_min NAPItype="NX_FLOAT32">32131
+            </time_channel_min>
+            <time_channel_max NAPItype="NX_FLOAT32">464563
+            </time_channel_max>
+        </IXtime_regime>
+        <IXtime_regime name="time_regime_2">
+            <number_time_channels NAPItype="NX_INT32">2352
+            </number_time_channels>
+            <time_channel_min NAPItype="NX_FLOAT32">603400.0000
+            </time_channel_min>
+            <time_channel_max NAPItype="NX_FLOAT32">4604320.0000
+            </time_channel_max>
+        </IXtime_regime>
+        <icp_version NAPItype="NX_CHAR[79]">SMi</icp_version>
+        <detector_table_file NAPItype="NX_CHAR[97]">The quick brown fox</detector_table_file>
+        <spectra_table_file NAPItype="NX_CHAR[91]">jumps over the</spectra_table_file>
+        <wiring_table_file NAPItype="NX_CHAR[83]">lazy dog</wiring_table_file>
+        <monitor_spectrum NAPItype="NX_INT32">3422
+        </monitor_spectrum>
+        <monitor_sum NAPItype="NX_UINT32">342
+        </monitor_sum>
+        <total_mevents NAPItype="NX_FLOAT32">4234.1231
+        </total_mevents>
+        <comment NAPItype="NX_CHAR[11]">UNSPECIFIED</comment>
+        <field_label NAPItype="NX_CHAR[11]">UNSPECIFIED</field_label>
+        <instrument_geometry NAPItype="NX_CHAR[11]">UNSPECIFIED</instrument_geometry>
+        <script_name NAPItype="NX_CHAR[2]">1
+        </script_name>
+        <sample_name NAPItype="NX_CHAR[2]">1
+        </sample_name>
+        <sample_orientation NAPItype="NX_CHAR[2]">2
+        </sample_orientation>
+        <temperature_label NAPItype="NX_CHAR[11]">UNSPECIFIED</temperature_label>
+        <npratio_average NAPItype="NX_FLOAT32">31.0000
+        </npratio_average>
+        <isis_cycle NAPItype="NX_CHAR[4]">20_1</isis_cycle>
+        <seci_config NAPItype="NX_CHAR[17]">Based cyberman</seci_config>
+        <event_mode NAPItype="NX_FLOAT64">0.2300000
+        </event_mode>
+        <IXselog name="selog">
+            <IXseblock name="0
+">
+                <current_value NAPItype="NX_CHAR[3]">lol</current_value>
+                <setpoint_value NAPItype="NX_CHAR[3]">wtf</setpoint_value>
+                <average_value NAPItype="NX_CHAR[3]">m8</average_value>
+            </IXseblock>
+        </IXselog>
+    </NXentry>
+    <NXentry name="ENGINX00299085">
+        <title NAPItype="NX_CHAR[15]">Hello world</title>
+        <simulation_mode NAPItype="NX_CHAR[2]">NO</simulation_mode>
+        <user_name NAPItype="NX_CHAR[9]">kdslfs</user_name>
+        <local_contact NAPItype="NX_CHAR[11]">UNSPECIFIED</local_contact>
+        <user_institute NAPItype="NX_CHAR[11]">UNSPECIFIED</user_institute>
+        <experiment_identifier NAPItype="NX_CHAR[7]">21231</experiment_identifier>
+        <instrument_name NAPItype="NX_CHAR[6]">ENGINX</instrument_name>
+        <run_number NAPItype="NX_INT32">31231
+        </run_number>
+        <sample_id NAPItype="NX_CHAR[2]">321
+        </sample_id>
+        <measurement_first_run NAPItype="NX_INT32">31231
+        </measurement_first_run>
+        <measurement_id NAPItype="NX_CHAR[2]">31231
+        </measurement_id>
+        <measurement_label NAPItype="NX_CHAR[11]">UNSPECIFIED</measurement_label>
+        <measurement_type NAPItype="NX_CHAR[2]">0
+        </measurement_type>
+        <measurement_subid NAPItype="NX_CHAR[2]">0
+        </measurement_subid>
+        <start_time NAPItype="NX_CHAR[19]">2020-11-10T14:14:06</start_time>
+        <end_time NAPItype="NX_CHAR[19]">2020-11-10T14:14:12</end_time>
+        <duration NAPItype="NX_INT64">32131
+        </duration>
+        <proton_charge NAPItype="NX_FLOAT32">0.170923
+        </proton_charge>
+        <raw_frames NAPItype="NX_UINT32">231231
+        </raw_frames>
+        <good_frames NAPItype="NX_UINT32">31231
+        </good_frames>
+        <number_periods NAPItype="NX_INT32">3213
+        </number_periods>
+        <number_spectra NAPItype="NX_INT32">543
+        </number_spectra>
+        <number_detectors NAPItype="NX_INT32">523
+        </number_detectors>
+        <number_time_regimes NAPItype="NX_INT32">2
+        </number_time_regimes>
+        <frame_sync NAPItype="NX_CHAR[3]">Sok</frame_sync>
+        <IXtime_regime name="time_regime_1">
+            <number_time_channels NAPItype="NX_INT32">342342
+            </number_time_channels>
+            <time_channel_min NAPItype="NX_FLOAT32">432000.0000
+            </time_channel_min>
+            <time_channel_max NAPItype="NX_FLOAT32">43299.0000
+            </time_channel_max>
+        </IXtime_regime>
+        <IXtime_regime name="time_regime_2">
+            <number_time_channels NAPItype="NX_INT32">423420
+            </number_time_channels>
+            <time_channel_min NAPItype="NX_FLOAT32">6043200.0000
+            </time_channel_min>
+            <time_channel_max NAPItype="NX_FLOAT32">4604300.0000
+            </time_channel_max>
+        </IXtime_regime>
+        <icp_version NAPItype="NX_CHAR[79]">332sdasdasd</icp_version>
+        <detector_table_file NAPItype="NX_CHAR[97]">dsada</detector_table_file>
+        <spectra_table_file NAPItype="NX_CHAR[91]">sdada</spectra_table_file>
+        <wiring_table_file NAPItype="NX_CHAR[83]">sdada</wiring_table_file>
+        <monitor_spectrum NAPItype="NX_INT32">23423
+        </monitor_spectrum>
+        <monitor_sum NAPItype="NX_UINT32">4232
+        </monitor_sum>
+        <total_mevents NAPItype="NX_FLOAT32">234.1231
+        </total_mevents>
+        <comment NAPItype="NX_CHAR[11]">UNSPECIFIED</comment>
+        <field_label NAPItype="NX_CHAR[11]">UNSPECIFIED</field_label>
+        <instrument_geometry NAPItype="NX_CHAR[11]">UNSPECIFIED</instrument_geometry>
+        <script_name NAPItype="NX_CHAR[2]">0
+        </script_name>
+        <sample_name NAPItype="NX_CHAR[2]">0
+        </sample_name>
+        <sample_orientation NAPItype="NX_CHAR[2]">0
+        </sample_orientation>
+        <temperature_label NAPItype="NX_CHAR[11]">UNSPECIFIED</temperature_label>
+        <npratio_average NAPItype="NX_FLOAT32">3.1415926
+        </npratio_average>
+        <isis_cycle NAPItype="NX_CHAR[4]">20_2</isis_cycle>
+        <seci_config NAPItype="NX_CHAR[17]">based cyberman</seci_config>
+        <event_mode NAPItype="NX_FLOAT64">323100000
+        </event_mode>
+        <IXselog name="selog">
+            <IXseblock name="0
+">
+                <current_value NAPItype="NX_CHAR[3]">kjl</current_value>
+                <setpoint_value NAPItype="NX_CHAR[3]">Nadsa</setpoint_value>
+                <average_value NAPItype="NX_CHAR[3]">Nasda</average_value>
+            </IXseblock>
+        </IXselog>
+    </NXentry>
+</NXroot>


### PR DESCRIPTION
Closes #509.

## Description

Adds a shared Valkey cache helper to run-detection. The helper handles lazy client creation, `VALKEY_URL` configuration, JSON serialization, TTL-based writes, and graceful fallback when Valkey is unavailable.

The EnginX journal lookup now uses this cache to store the derived run-number-to-cycle map, keyed as `run_detection:enginx:run_number_cycle_map`. On startup or lookup, run-detection first tries to read the cached map; if it is missing or Valkey is unavailable, it parses the journal XML files and writes the derived map back to Valkey with a TTL.

## Local testing

Start Valkey:
```shell
docker run --rm -d --name run-detection-valkey -p 6379:6379 valkey/valkey:8-alpine
```

Run from repo root:
```shell
$env:VALKEY_URL = "redis://localhost:6379/0"
$env:ENGINX_JOURNAL_DIR = "test/test_data/e2e_data/NDXENGINX/Instrument/logs/journal"
$env:ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_TTL_SECONDS = "3600"

@'
from rundetection.cache import cache_get_json
from rundetection.rules.enginx_rules import (
    ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY,
    build_enginx_run_number_cycle_map,
)

mapping = build_enginx_run_number_cycle_map()
cached = cache_get_json(ENGINX_RUN_NUMBER_CYCLE_MAP_CACHE_KEY)

print(mapping.get(241391))
print(cached is not None)
print(cached.get("241391"))
'@ | python
```

Expected output:
```
20_1
True
20_1
```