### PR TITLE
Add Valkey caching for EnginX journal lookup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ dependencies = [
     "pika==1.4.0",
     "h5py==3.16.0",
     "xmltodict==1.0.4",
-    "requests==2.33.1"
+    "requests==2.33.1",
+    "redis==7.4.0",
 ]
 
 

--- a/rundetection/cache.py
+++ b/rundetection/cache.py
@@ -1,0 +1,99 @@
+"""Valkey cache helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from functools import cache
+from typing import Any
+
+from redis import Redis
+from redis.exceptions import RedisError
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_VALKEY_URL = "redis://valkey.valkey.svc.cluster.local:6379/0"
+
+
+@dataclass(slots=True)
+class _State:
+    client: Redis | None = None
+    disabled: bool = False
+
+
+@cache
+def _state() -> _State:
+    return _State()
+
+
+def _create_client() -> Redis:
+    url = os.environ.get("VALKEY_URL", DEFAULT_VALKEY_URL)
+    return Redis.from_url(
+        url,
+        decode_responses=True,
+        socket_connect_timeout=0.5,
+        socket_timeout=1,
+        retry_on_timeout=False,
+    )
+
+
+def get_valkey_client() -> Redis | None:
+    """Return a shared Valkey client, or None if Valkey is unavailable."""
+    state = _state()
+    if state.disabled:
+        return None
+    if state.client is None:
+        try:
+            state.client = _create_client()
+        except (RedisError, ValueError) as exc:
+            state.disabled = True
+            logger.warning("Valkey cache disabled: %s", exc)
+            return None
+    return state.client
+
+
+def _disable(exc: Exception) -> None:
+    state = _state()
+    state.disabled = True
+    logger.warning("Valkey cache disabled: %s", exc)
+
+
+def cache_get_json(key: str) -> Any | None:
+    """Return a JSON value from Valkey, or None on miss/error."""
+    client = get_valkey_client()
+    if client is None:
+        return None
+    try:
+        raw = client.get(key)
+    except RedisError as exc:
+        _disable(exc)
+        return None
+    if raw is None:
+        return None
+    if isinstance(raw, (bytes, bytearray)):
+        raw = raw.decode("utf-8")
+    if not isinstance(raw, str):
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+
+def cache_set_json(key: str, value: Any, ttl: int) -> None:
+    """Store a JSON value in Valkey when caching is enabled."""
+    if ttl <= 0:
+        return
+    client = get_valkey_client()
+    if client is None:
+        return
+    try:
+        payload = json.dumps(value)
+    except TypeError:
+        return
+    try:
+        client.setex(key, ttl, payload)
+    except RedisError as exc:
+        _disable(exc)

--- a/rundetection/rules/enginx_rules.py
+++ b/rundetection/rules/enginx_rules.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Self
 
 import xmltodict
 
+from rundetection.cache import cache_get_json, cache_set_json
 from rundetection.exceptions import RuleViolationError
 from rundetection.rules.rule import Rule
 
@@ -19,6 +20,23 @@ if TYPE_CHECKING:
     from rundetection.job_requests import JobRequest
 
 logger = logging.getLogger(__name__)
+
+ENGINX_JOURNAL_DIR = Path("/archive/NDXENGINX/Instrument/logs/journal")
+ENGINX_MAP_CACHE_KEY = "run-detection:enginx:run-cycle-map"
+ENGINX_MAP_CACHE_TTL = int(os.environ.get("ENGINX_MAP_CACHE_TTL_SECONDS", "86400"))
+
+
+def _cached_enginx_map() -> dict[int, str] | None:
+    """Return the cached EnginX run cycle map when the payload is usable."""
+    cached = cache_get_json(ENGINX_MAP_CACHE_KEY)
+    if not isinstance(cached, dict) or not cached:
+        return None
+    try:
+        mapping = {int(run): cycle for run, cycle in cached.items() if isinstance(cycle, str)}
+    except (TypeError, ValueError):
+        logger.warning("Ignoring invalid EnginX journal cache payload")
+        return None
+    return mapping or None
 
 
 class EnginxGroupRule(Rule[str]):
@@ -137,6 +155,10 @@ def build_enginx_run_number_cycle_map() -> dict[int, str]:
     :return: A dict[int, str] mapping run numbers to cycle strings.
     """
     logger.info("Building run number cycle map")
+    cached = _cached_enginx_map()
+    if cached is not None:
+        return cached
+
     mapping = {}
 
     def _walk_node(node: list[Any] | dict[str, Any], journal_file: str) -> None:
@@ -152,10 +174,12 @@ def build_enginx_run_number_cycle_map() -> dict[int, str]:
                 _walk_node(item, journal_file)
 
     logger.info("Reading journal files...")
-    for path in Path("/archive/NDXENGINX/Instrument/logs/journal").glob("*.xml"):
+    for path in ENGINX_JOURNAL_DIR.glob("*.xml"):
         logger.info("Reading journal file: %s", path)
         with path.open() as journal:
             journal_dict = xmltodict.parse(journal.read())
             _walk_node(journal_dict, path.stem)
     logger.info("Mapping complete")
+    if mapping:
+        cache_set_json(ENGINX_MAP_CACHE_KEY, mapping, ENGINX_MAP_CACHE_TTL)
     return mapping

--- a/test/rules/test_enginx_rules.py
+++ b/test/rules/test_enginx_rules.py
@@ -8,10 +8,13 @@ import pytest
 from rundetection.exceptions import RuleViolationError
 from rundetection.ingestion.ingest import JobRequest
 from rundetection.rules.enginx_rules import (
+    ENGINX_MAP_CACHE_KEY,
+    ENGINX_MAP_CACHE_TTL,
     EnginxBasePathRule,
     EnginxCeriaPathRule,
     EnginxGroupRule,
     EnginxVanadiumPathRule,
+    build_enginx_run_number_cycle_map,
 )
 
 
@@ -117,3 +120,59 @@ def test_coerce_run_invalid_raises():
     """Test that invalid run raises an exception."""
     with pytest.raises(ValueError):  # noqa: PT011
         EnginxBasePathRule._coerce_run("no-digits")
+
+
+def test_build_enginx_run_number_cycle_map_uses_cache():
+    """The EnginX run cycle map should be returned from Valkey when present."""
+    build_enginx_run_number_cycle_map.cache_clear()
+
+    with (
+        patch("rundetection.rules.enginx_rules.cache_get_json", return_value={"241391": "20_1"}) as cache_get,
+        patch("rundetection.rules.enginx_rules.cache_set_json") as cache_set,
+        patch("rundetection.rules.enginx_rules.ENGINX_JOURNAL_DIR") as journal_dir,
+    ):
+        mapping = build_enginx_run_number_cycle_map()
+
+    assert mapping == {241391: "20_1"}
+    cache_get.assert_called_once_with(ENGINX_MAP_CACHE_KEY)
+    cache_set.assert_not_called()
+    journal_dir.glob.assert_not_called()
+
+    build_enginx_run_number_cycle_map.cache_clear()
+
+
+def test_build_enginx_run_number_cycle_map_sets_cache(monkeypatch):
+    """The EnginX run cycle map should be cached after reading journals."""
+    build_enginx_run_number_cycle_map.cache_clear()
+    journal_dir = Path("test/test_data/e2e_data/NDXENGINX/Instrument/logs/journal")
+    monkeypatch.setattr("rundetection.rules.enginx_rules.ENGINX_JOURNAL_DIR", journal_dir)
+
+    with (
+        patch("rundetection.rules.enginx_rules.cache_get_json", return_value=None),
+        patch("rundetection.rules.enginx_rules.cache_set_json") as cache_set,
+    ):
+        mapping = build_enginx_run_number_cycle_map()
+
+    assert mapping[241391] == "20_1"
+    assert mapping[299080] == "20_1"
+    cache_set.assert_called_once_with(ENGINX_MAP_CACHE_KEY, mapping, ENGINX_MAP_CACHE_TTL)
+
+    build_enginx_run_number_cycle_map.cache_clear()
+
+
+def test_build_enginx_run_number_cycle_map_does_not_cache_empty_map(monkeypatch):
+    """An unavailable journal directory should not poison Valkey with an empty map."""
+    build_enginx_run_number_cycle_map.cache_clear()
+    empty_dir = Path("test/test_data/e2e_data/NDXENGINX/Instrument/logs/missing")
+    monkeypatch.setattr("rundetection.rules.enginx_rules.ENGINX_JOURNAL_DIR", empty_dir)
+
+    with (
+        patch("rundetection.rules.enginx_rules.cache_get_json", return_value=None),
+        patch("rundetection.rules.enginx_rules.cache_set_json") as cache_set,
+    ):
+        mapping = build_enginx_run_number_cycle_map()
+
+    assert mapping == {}
+    cache_set.assert_not_called()
+
+    build_enginx_run_number_cycle_map.cache_clear()

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -1,0 +1,95 @@
+"""Tests for Valkey cache helpers."""
+
+import json
+import os
+from unittest.mock import Mock, patch
+
+from redis.exceptions import RedisError
+
+from rundetection.cache import _create_client, _state, cache_get_json, cache_set_json, get_valkey_client
+
+TTL = 30
+
+
+def setup_function() -> None:
+    """Clear cached Valkey state between tests."""
+    _state.cache_clear()
+
+
+def test_cache_get_json_returns_none_without_client():
+    """No client should behave like a cache miss."""
+    with patch("rundetection.cache.get_valkey_client", return_value=None):
+        assert cache_get_json("key") is None
+
+
+def test_cache_get_json_returns_parsed_payload():
+    """JSON cache values should be decoded."""
+    client = Mock()
+    client.get.return_value = '{"answer": 42}'
+
+    with patch("rundetection.cache.get_valkey_client", return_value=client):
+        assert cache_get_json("key") == {"answer": 42}
+
+    client.get.assert_called_once_with("key")
+
+
+def test_cache_get_json_returns_none_for_bad_json():
+    """Invalid JSON should behave like a cache miss."""
+    client = Mock()
+    client.get.return_value = "not-json"
+
+    with patch("rundetection.cache.get_valkey_client", return_value=client):
+        assert cache_get_json("key") is None
+
+
+def test_cache_get_json_disables_on_redis_error():
+    """Redis errors should disable cache access for the process."""
+    client = Mock()
+    client.get.side_effect = RedisError("boom")
+
+    with patch("rundetection.cache.get_valkey_client", return_value=client):
+        assert cache_get_json("key") is None
+
+    assert _state().disabled is True
+
+
+def test_cache_set_json_sets_payload_with_ttl():
+    """JSON cache values should be stored with the requested TTL."""
+    client = Mock()
+
+    with patch("rundetection.cache.get_valkey_client", return_value=client):
+        cache_set_json("key", {"answer": 42}, TTL)
+
+    client.setex.assert_called_once()
+    key, ttl, payload = client.setex.call_args[0]
+    assert key == "key"
+    assert ttl == TTL
+    assert json.loads(payload) == {"answer": 42}
+
+
+def test_cache_set_json_skips_non_positive_ttl():
+    """Non-positive TTL values should skip cache writes."""
+    with patch("rundetection.cache.get_valkey_client") as get_client:
+        cache_set_json("key", {"answer": 42}, 0)
+
+    get_client.assert_not_called()
+
+
+def test_create_client_uses_valkey_url():
+    """The Valkey URL should come from the environment when set."""
+    with (
+        patch.dict(os.environ, {"VALKEY_URL": "redis://localhost:6379/1"}),
+        patch("rundetection.cache.Redis.from_url") as from_url,
+    ):
+        _create_client()
+
+    from_url.assert_called_once()
+    assert from_url.call_args[0][0] == "redis://localhost:6379/1"
+
+
+def test_get_valkey_client_disables_on_create_error():
+    """Client creation errors should disable further cache attempts."""
+    with patch("rundetection.cache._create_client", side_effect=RedisError("boom")):
+        assert get_valkey_client() is None
+
+    assert _state().disabled is True

--- a/test/test_data/e2e_data/NDXENGINX/Instrument/logs/journal/journal_21_1.xml
+++ b/test/test_data/e2e_data/NDXENGINX/Instrument/logs/journal/journal_21_1.xml
@@ -1,0 +1,281 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<NXroot NeXus_version="4.3.0" XML_version="mxml"
+        file_name="c:\data\journal_20_2.xml"
+        xmlns="http://definition.nexusformat.org/schema/3.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://definition.nexusformat.org/schema/3.0"
+        file_time="2020-09-10T10:33:14+00:00">
+    <NXentry name="ENGINX00324668">
+        <title NAPItype="NX_CHAR[14]">Some Title</title>
+        <simulation_mode NAPItype="NX_CHAR[2]">NO</simulation_mode>
+        <user_name NAPItype="NX_CHAR[11]">UNSPECIFIED</user_name>
+        <local_contact NAPItype="NX_CHAR[11]">UNSPECIFIED</local_contact>
+        <user_institute NAPItype="NX_CHAR[11]">UNSPECIFIED</user_institute>
+        <experiment_identifier NAPItype="NX_CHAR[1]">0</experiment_identifier>
+        <instrument_name NAPItype="NX_CHAR[6]">ENGINX</instrument_name>
+        <run_number NAPItype="NX_INT32">324667
+        </run_number>
+        <sample_id NAPItype="NX_CHAR[2]">0
+        </sample_id>
+        <measurement_first_run NAPItype="NX_INT32">0
+        </measurement_first_run>
+        <measurement_id NAPItype="NX_CHAR[2]">0
+        </measurement_id>
+        <measurement_label NAPItype="NX_CHAR[11]">UNSPECIFIED</measurement_label>
+        <measurement_type NAPItype="NX_CHAR[2]">0
+        </measurement_type>
+        <measurement_subid NAPItype="NX_CHAR[2]">0
+        </measurement_subid>
+        <start_time NAPItype="NX_CHAR[19]">2020-09-10T10:33:00</start_time>
+        <end_time NAPItype="NX_CHAR[19]">2020-09-10T10:33:11</end_time>
+        <duration NAPItype="NX_INT64">11
+        </duration>
+        <proton_charge NAPItype="NX_FLOAT32">1.2
+        </proton_charge>
+        <raw_frames NAPItype="NX_UINT32">32
+        </raw_frames>
+        <good_frames NAPItype="NX_UINT32">32
+        </good_frames>
+        <number_periods NAPItype="NX_INT32">32
+        </number_periods>
+        <number_spectra NAPItype="NX_INT32">32
+        </number_spectra>
+        <number_detectors NAPItype="NX_INT32">32
+        </number_detectors>
+        <number_time_regimes NAPItype="NX_INT32">32
+        </number_time_regimes>
+        <frame_sync NAPItype="NX_CHAR[3]">LOL</frame_sync>
+        <IXtime_regime name="time_regime_1">
+            <number_time_channels NAPItype="NX_INT32">12
+            </number_time_channels>
+            <time_channel_min NAPItype="NX_FLOAT32">9000.0000
+            </time_channel_min>
+            <time_channel_max NAPItype="NX_FLOAT32">999.0000
+            </time_channel_max>
+        </IXtime_regime>
+        <IXtime_regime name="time_regime_2">
+            <number_time_channels NAPItype="NX_INT32">402
+            </number_time_channels>
+            <time_channel_min NAPItype="NX_FLOAT32">4200.0000
+            </time_channel_min>
+            <time_channel_max NAPItype="NX_FLOAT32">4100.0000
+            </time_channel_max>
+        </IXtime_regime>
+        <icp_version NAPItype="NX_CHAR[79]">Super Secret ICP Version</icp_version>
+        <detector_table_file NAPItype="NX_CHAR[97]">wow a transdet table</detector_table_file>
+        <spectra_table_file NAPItype="NX_CHAR[91]">wow a transdet spectra</spectra_table_file>
+        <wiring_table_file NAPItype="NX_CHAR[83]">ahhhh wireeee</wiring_table_file>
+        <monitor_spectrum NAPItype="NX_INT32">12
+        </monitor_spectrum>
+        <monitor_sum NAPItype="NX_UINT32">3
+        </monitor_sum>
+        <total_mevents NAPItype="NX_FLOAT32">1.23
+        </total_mevents>
+        <comment NAPItype="NX_CHAR[11]">UNSPECIFIED</comment>
+        <field_label NAPItype="NX_CHAR[11]">UNSPECIFIED</field_label>
+        <instrument_geometry NAPItype="NX_CHAR[11]">UNSPECIFIED</instrument_geometry>
+        <script_name NAPItype="NX_CHAR[2]">0
+        </script_name>
+        <sample_name NAPItype="NX_CHAR[2]">0
+        </sample_name>
+        <sample_orientation NAPItype="NX_CHAR[2]">0
+        </sample_orientation>
+        <temperature_label NAPItype="NX_CHAR[11]">UNSPECIFIED</temperature_label>
+        <npratio_average NAPItype="NX_FLOAT32">0.0000
+        </npratio_average>
+        <isis_cycle NAPItype="NX_CHAR[4]">20_2</isis_cycle>
+        <seci_config NAPItype="NX_CHAR[17]">based cyberman</seci_config>
+        <event_mode NAPItype="NX_FLOAT64">0.00000
+        </event_mode>
+        <IXselog name="selog">
+            <IXseblock name="0
+">
+                <current_value NAPItype="NX_CHAR[3]">gran</current_value>
+                <setpoint_value NAPItype="NX_CHAR[3]">nan</setpoint_value>
+                <average_value NAPItype="NX_CHAR[3]">man</average_value>
+            </IXseblock>
+        </IXselog>
+    </NXentry>
+    <NXentry name="ENGINX00241392">
+        <title NAPItype="NX_CHAR[14]">Sir</title>
+        <simulation_mode NAPItype="NX_CHAR[2]">YES</simulation_mode>
+        <user_name NAPItype="NX_CHAR[11]">UNS</user_name>
+        <local_contact NAPItype="NX_CHAR[11]">UNSPECIFIED</local_contact>
+        <user_institute NAPItype="NX_CHAR[11]">UNSPECIFIED</user_institute>
+        <experiment_identifier NAPItype="NX_CHAR[1]">0</experiment_identifier>
+        <instrument_name NAPItype="NX_CHAR[6]">ENGINX</instrument_name>
+        <run_number NAPItype="NX_INT32">2131
+        </run_number>
+        <sample_id NAPItype="NX_CHAR[2]">123
+        </sample_id>
+        <measurement_first_run NAPItype="NX_INT32">123
+        </measurement_first_run>
+        <measurement_id NAPItype="NX_CHAR[2]">123
+        </measurement_id>
+        <measurement_label NAPItype="NX_CHAR[11]">ECIFIED</measurement_label>
+        <measurement_type NAPItype="NX_CHAR[2]">1231
+        </measurement_type>
+        <measurement_subid NAPItype="NX_CHAR[2]">1231231
+        </measurement_subid>
+        <start_time NAPItype="NX_CHAR[19]">2020-09-10T10:33:22</start_time>
+        <end_time NAPItype="NX_CHAR[19]">2020-09-10T10:33:30</end_time>
+        <duration NAPItype="NX_INT64">1231
+        </duration>
+        <proton_charge NAPItype="NX_FLOAT32">0.432131234784
+        </proton_charge>
+        <raw_frames NAPItype="NX_UINT32">41231
+        </raw_frames>
+        <good_frames NAPItype="NX_UINT32">4534
+        </good_frames>
+        <number_periods NAPItype="NX_INT32">76575
+        </number_periods>
+        <number_spectra NAPItype="NX_INT32">342
+        </number_spectra>
+        <number_detectors NAPItype="NX_INT32">2342
+        </number_detectors>
+        <number_time_regimes NAPItype="NX_INT32">3242
+        </number_time_regimes>
+        <frame_sync NAPItype="NX_CHAR[16]">wow</frame_sync>
+        <IXtime_regime name="time_regime_1">
+            <number_time_channels NAPItype="NX_INT32">1321231
+            </number_time_channels>
+            <time_channel_min NAPItype="NX_FLOAT32">32131
+            </time_channel_min>
+            <time_channel_max NAPItype="NX_FLOAT32">464563
+            </time_channel_max>
+        </IXtime_regime>
+        <IXtime_regime name="time_regime_2">
+            <number_time_channels NAPItype="NX_INT32">2352
+            </number_time_channels>
+            <time_channel_min NAPItype="NX_FLOAT32">603400.0000
+            </time_channel_min>
+            <time_channel_max NAPItype="NX_FLOAT32">4604320.0000
+            </time_channel_max>
+        </IXtime_regime>
+        <icp_version NAPItype="NX_CHAR[79]">SMi</icp_version>
+        <detector_table_file NAPItype="NX_CHAR[97]">The quick brown fox</detector_table_file>
+        <spectra_table_file NAPItype="NX_CHAR[91]">jumps over the</spectra_table_file>
+        <wiring_table_file NAPItype="NX_CHAR[83]">lazy dog</wiring_table_file>
+        <monitor_spectrum NAPItype="NX_INT32">3422
+        </monitor_spectrum>
+        <monitor_sum NAPItype="NX_UINT32">342
+        </monitor_sum>
+        <total_mevents NAPItype="NX_FLOAT32">4234.1231
+        </total_mevents>
+        <comment NAPItype="NX_CHAR[11]">UNSPECIFIED</comment>
+        <field_label NAPItype="NX_CHAR[11]">UNSPECIFIED</field_label>
+        <instrument_geometry NAPItype="NX_CHAR[11]">UNSPECIFIED</instrument_geometry>
+        <script_name NAPItype="NX_CHAR[2]">1
+        </script_name>
+        <sample_name NAPItype="NX_CHAR[2]">1
+        </sample_name>
+        <sample_orientation NAPItype="NX_CHAR[2]">2
+        </sample_orientation>
+        <temperature_label NAPItype="NX_CHAR[11]">UNSPECIFIED</temperature_label>
+        <npratio_average NAPItype="NX_FLOAT32">31.0000
+        </npratio_average>
+        <isis_cycle NAPItype="NX_CHAR[4]">20_1</isis_cycle>
+        <seci_config NAPItype="NX_CHAR[17]">Based cyberman</seci_config>
+        <event_mode NAPItype="NX_FLOAT64">0.2300000
+        </event_mode>
+        <IXselog name="selog">
+            <IXseblock name="0
+">
+                <current_value NAPItype="NX_CHAR[3]">lol</current_value>
+                <setpoint_value NAPItype="NX_CHAR[3]">wtf</setpoint_value>
+                <average_value NAPItype="NX_CHAR[3]">m8</average_value>
+            </IXseblock>
+        </IXselog>
+    </NXentry>
+    <NXentry name="ENGINX00299083">
+        <title NAPItype="NX_CHAR[15]">Hello world</title>
+        <simulation_mode NAPItype="NX_CHAR[2]">NO</simulation_mode>
+        <user_name NAPItype="NX_CHAR[9]">kdslfs</user_name>
+        <local_contact NAPItype="NX_CHAR[11]">UNSPECIFIED</local_contact>
+        <user_institute NAPItype="NX_CHAR[11]">UNSPECIFIED</user_institute>
+        <experiment_identifier NAPItype="NX_CHAR[7]">21231</experiment_identifier>
+        <instrument_name NAPItype="NX_CHAR[6]">ENGINX</instrument_name>
+        <run_number NAPItype="NX_INT32">31231
+        </run_number>
+        <sample_id NAPItype="NX_CHAR[2]">321
+        </sample_id>
+        <measurement_first_run NAPItype="NX_INT32">31231
+        </measurement_first_run>
+        <measurement_id NAPItype="NX_CHAR[2]">31231
+        </measurement_id>
+        <measurement_label NAPItype="NX_CHAR[11]">UNSPECIFIED</measurement_label>
+        <measurement_type NAPItype="NX_CHAR[2]">0
+        </measurement_type>
+        <measurement_subid NAPItype="NX_CHAR[2]">0
+        </measurement_subid>
+        <start_time NAPItype="NX_CHAR[19]">2020-11-10T14:14:06</start_time>
+        <end_time NAPItype="NX_CHAR[19]">2020-11-10T14:14:12</end_time>
+        <duration NAPItype="NX_INT64">32131
+        </duration>
+        <proton_charge NAPItype="NX_FLOAT32">0.170923
+        </proton_charge>
+        <raw_frames NAPItype="NX_UINT32">231231
+        </raw_frames>
+        <good_frames NAPItype="NX_UINT32">31231
+        </good_frames>
+        <number_periods NAPItype="NX_INT32">3213
+        </number_periods>
+        <number_spectra NAPItype="NX_INT32">543
+        </number_spectra>
+        <number_detectors NAPItype="NX_INT32">523
+        </number_detectors>
+        <number_time_regimes NAPItype="NX_INT32">2
+        </number_time_regimes>
+        <frame_sync NAPItype="NX_CHAR[3]">Sok</frame_sync>
+        <IXtime_regime name="time_regime_1">
+            <number_time_channels NAPItype="NX_INT32">342342
+            </number_time_channels>
+            <time_channel_min NAPItype="NX_FLOAT32">432000.0000
+            </time_channel_min>
+            <time_channel_max NAPItype="NX_FLOAT32">43299.0000
+            </time_channel_max>
+        </IXtime_regime>
+        <IXtime_regime name="time_regime_2">
+            <number_time_channels NAPItype="NX_INT32">423420
+            </number_time_channels>
+            <time_channel_min NAPItype="NX_FLOAT32">6043200.0000
+            </time_channel_min>
+            <time_channel_max NAPItype="NX_FLOAT32">4604300.0000
+            </time_channel_max>
+        </IXtime_regime>
+        <icp_version NAPItype="NX_CHAR[79]">332sdasdasd</icp_version>
+        <detector_table_file NAPItype="NX_CHAR[97]">dsada</detector_table_file>
+        <spectra_table_file NAPItype="NX_CHAR[91]">sdada</spectra_table_file>
+        <wiring_table_file NAPItype="NX_CHAR[83]">sdada</wiring_table_file>
+        <monitor_spectrum NAPItype="NX_INT32">23423
+        </monitor_spectrum>
+        <monitor_sum NAPItype="NX_UINT32">4232
+        </monitor_sum>
+        <total_mevents NAPItype="NX_FLOAT32">234.1231
+        </total_mevents>
+        <comment NAPItype="NX_CHAR[11]">UNSPECIFIED</comment>
+        <field_label NAPItype="NX_CHAR[11]">UNSPECIFIED</field_label>
+        <instrument_geometry NAPItype="NX_CHAR[11]">UNSPECIFIED</instrument_geometry>
+        <script_name NAPItype="NX_CHAR[2]">0
+        </script_name>
+        <sample_name NAPItype="NX_CHAR[2]">0
+        </sample_name>
+        <sample_orientation NAPItype="NX_CHAR[2]">0
+        </sample_orientation>
+        <temperature_label NAPItype="NX_CHAR[11]">UNSPECIFIED</temperature_label>
+        <npratio_average NAPItype="NX_FLOAT32">3.1415926
+        </npratio_average>
+        <isis_cycle NAPItype="NX_CHAR[4]">20_2</isis_cycle>
+        <seci_config NAPItype="NX_CHAR[17]">based cyberman</seci_config>
+        <event_mode NAPItype="NX_FLOAT64">323100000
+        </event_mode>
+        <IXselog name="selog">
+            <IXseblock name="0
+">
+                <current_value NAPItype="NX_CHAR[3]">kjl</current_value>
+                <setpoint_value NAPItype="NX_CHAR[3]">Nadsa</setpoint_value>
+                <average_value NAPItype="NX_CHAR[3]">Nasda</average_value>
+            </IXseblock>
+        </IXselog>
+    </NXentry>
+</NXroot>

--- a/test/test_data/e2e_data/NDXENGINX/Instrument/logs/journal/journal_22_1.xml
+++ b/test/test_data/e2e_data/NDXENGINX/Instrument/logs/journal/journal_22_1.xml
@@ -1,0 +1,281 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<NXroot NeXus_version="4.3.0" XML_version="mxml"
+        file_name="c:\data\journal_20_2.xml"
+        xmlns="http://definition.nexusformat.org/schema/3.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://definition.nexusformat.org/schema/3.0"
+        file_time="2020-09-10T10:33:14+00:00">
+    <NXentry name="ENGINX00324669">
+        <title NAPItype="NX_CHAR[14]">Some Title</title>
+        <simulation_mode NAPItype="NX_CHAR[2]">NO</simulation_mode>
+        <user_name NAPItype="NX_CHAR[11]">UNSPECIFIED</user_name>
+        <local_contact NAPItype="NX_CHAR[11]">UNSPECIFIED</local_contact>
+        <user_institute NAPItype="NX_CHAR[11]">UNSPECIFIED</user_institute>
+        <experiment_identifier NAPItype="NX_CHAR[1]">0</experiment_identifier>
+        <instrument_name NAPItype="NX_CHAR[6]">ENGINX</instrument_name>
+        <run_number NAPItype="NX_INT32">324667
+        </run_number>
+        <sample_id NAPItype="NX_CHAR[2]">0
+        </sample_id>
+        <measurement_first_run NAPItype="NX_INT32">0
+        </measurement_first_run>
+        <measurement_id NAPItype="NX_CHAR[2]">0
+        </measurement_id>
+        <measurement_label NAPItype="NX_CHAR[11]">UNSPECIFIED</measurement_label>
+        <measurement_type NAPItype="NX_CHAR[2]">0
+        </measurement_type>
+        <measurement_subid NAPItype="NX_CHAR[2]">0
+        </measurement_subid>
+        <start_time NAPItype="NX_CHAR[19]">2020-09-10T10:33:00</start_time>
+        <end_time NAPItype="NX_CHAR[19]">2020-09-10T10:33:11</end_time>
+        <duration NAPItype="NX_INT64">11
+        </duration>
+        <proton_charge NAPItype="NX_FLOAT32">1.2
+        </proton_charge>
+        <raw_frames NAPItype="NX_UINT32">32
+        </raw_frames>
+        <good_frames NAPItype="NX_UINT32">32
+        </good_frames>
+        <number_periods NAPItype="NX_INT32">32
+        </number_periods>
+        <number_spectra NAPItype="NX_INT32">32
+        </number_spectra>
+        <number_detectors NAPItype="NX_INT32">32
+        </number_detectors>
+        <number_time_regimes NAPItype="NX_INT32">32
+        </number_time_regimes>
+        <frame_sync NAPItype="NX_CHAR[3]">LOL</frame_sync>
+        <IXtime_regime name="time_regime_1">
+            <number_time_channels NAPItype="NX_INT32">12
+            </number_time_channels>
+            <time_channel_min NAPItype="NX_FLOAT32">9000.0000
+            </time_channel_min>
+            <time_channel_max NAPItype="NX_FLOAT32">999.0000
+            </time_channel_max>
+        </IXtime_regime>
+        <IXtime_regime name="time_regime_2">
+            <number_time_channels NAPItype="NX_INT32">402
+            </number_time_channels>
+            <time_channel_min NAPItype="NX_FLOAT32">4200.0000
+            </time_channel_min>
+            <time_channel_max NAPItype="NX_FLOAT32">4100.0000
+            </time_channel_max>
+        </IXtime_regime>
+        <icp_version NAPItype="NX_CHAR[79]">Super Secret ICP Version</icp_version>
+        <detector_table_file NAPItype="NX_CHAR[97]">wow a transdet table</detector_table_file>
+        <spectra_table_file NAPItype="NX_CHAR[91]">wow a transdet spectra</spectra_table_file>
+        <wiring_table_file NAPItype="NX_CHAR[83]">ahhhh wireeee</wiring_table_file>
+        <monitor_spectrum NAPItype="NX_INT32">12
+        </monitor_spectrum>
+        <monitor_sum NAPItype="NX_UINT32">3
+        </monitor_sum>
+        <total_mevents NAPItype="NX_FLOAT32">1.23
+        </total_mevents>
+        <comment NAPItype="NX_CHAR[11]">UNSPECIFIED</comment>
+        <field_label NAPItype="NX_CHAR[11]">UNSPECIFIED</field_label>
+        <instrument_geometry NAPItype="NX_CHAR[11]">UNSPECIFIED</instrument_geometry>
+        <script_name NAPItype="NX_CHAR[2]">0
+        </script_name>
+        <sample_name NAPItype="NX_CHAR[2]">0
+        </sample_name>
+        <sample_orientation NAPItype="NX_CHAR[2]">0
+        </sample_orientation>
+        <temperature_label NAPItype="NX_CHAR[11]">UNSPECIFIED</temperature_label>
+        <npratio_average NAPItype="NX_FLOAT32">0.0000
+        </npratio_average>
+        <isis_cycle NAPItype="NX_CHAR[4]">20_2</isis_cycle>
+        <seci_config NAPItype="NX_CHAR[17]">based cyberman</seci_config>
+        <event_mode NAPItype="NX_FLOAT64">0.00000
+        </event_mode>
+        <IXselog name="selog">
+            <IXseblock name="0
+">
+                <current_value NAPItype="NX_CHAR[3]">gran</current_value>
+                <setpoint_value NAPItype="NX_CHAR[3]">nan</setpoint_value>
+                <average_value NAPItype="NX_CHAR[3]">man</average_value>
+            </IXseblock>
+        </IXselog>
+    </NXentry>
+    <NXentry name="ENGINX00241396">
+        <title NAPItype="NX_CHAR[14]">Sir</title>
+        <simulation_mode NAPItype="NX_CHAR[2]">YES</simulation_mode>
+        <user_name NAPItype="NX_CHAR[11]">UNS</user_name>
+        <local_contact NAPItype="NX_CHAR[11]">UNSPECIFIED</local_contact>
+        <user_institute NAPItype="NX_CHAR[11]">UNSPECIFIED</user_institute>
+        <experiment_identifier NAPItype="NX_CHAR[1]">0</experiment_identifier>
+        <instrument_name NAPItype="NX_CHAR[6]">ENGINX</instrument_name>
+        <run_number NAPItype="NX_INT32">2131
+        </run_number>
+        <sample_id NAPItype="NX_CHAR[2]">123
+        </sample_id>
+        <measurement_first_run NAPItype="NX_INT32">123
+        </measurement_first_run>
+        <measurement_id NAPItype="NX_CHAR[2]">123
+        </measurement_id>
+        <measurement_label NAPItype="NX_CHAR[11]">ECIFIED</measurement_label>
+        <measurement_type NAPItype="NX_CHAR[2]">1231
+        </measurement_type>
+        <measurement_subid NAPItype="NX_CHAR[2]">1231231
+        </measurement_subid>
+        <start_time NAPItype="NX_CHAR[19]">2020-09-10T10:33:22</start_time>
+        <end_time NAPItype="NX_CHAR[19]">2020-09-10T10:33:30</end_time>
+        <duration NAPItype="NX_INT64">1231
+        </duration>
+        <proton_charge NAPItype="NX_FLOAT32">0.432131234784
+        </proton_charge>
+        <raw_frames NAPItype="NX_UINT32">41231
+        </raw_frames>
+        <good_frames NAPItype="NX_UINT32">4534
+        </good_frames>
+        <number_periods NAPItype="NX_INT32">76575
+        </number_periods>
+        <number_spectra NAPItype="NX_INT32">342
+        </number_spectra>
+        <number_detectors NAPItype="NX_INT32">2342
+        </number_detectors>
+        <number_time_regimes NAPItype="NX_INT32">3242
+        </number_time_regimes>
+        <frame_sync NAPItype="NX_CHAR[16]">wow</frame_sync>
+        <IXtime_regime name="time_regime_1">
+            <number_time_channels NAPItype="NX_INT32">1321231
+            </number_time_channels>
+            <time_channel_min NAPItype="NX_FLOAT32">32131
+            </time_channel_min>
+            <time_channel_max NAPItype="NX_FLOAT32">464563
+            </time_channel_max>
+        </IXtime_regime>
+        <IXtime_regime name="time_regime_2">
+            <number_time_channels NAPItype="NX_INT32">2352
+            </number_time_channels>
+            <time_channel_min NAPItype="NX_FLOAT32">603400.0000
+            </time_channel_min>
+            <time_channel_max NAPItype="NX_FLOAT32">4604320.0000
+            </time_channel_max>
+        </IXtime_regime>
+        <icp_version NAPItype="NX_CHAR[79]">SMi</icp_version>
+        <detector_table_file NAPItype="NX_CHAR[97]">The quick brown fox</detector_table_file>
+        <spectra_table_file NAPItype="NX_CHAR[91]">jumps over the</spectra_table_file>
+        <wiring_table_file NAPItype="NX_CHAR[83]">lazy dog</wiring_table_file>
+        <monitor_spectrum NAPItype="NX_INT32">3422
+        </monitor_spectrum>
+        <monitor_sum NAPItype="NX_UINT32">342
+        </monitor_sum>
+        <total_mevents NAPItype="NX_FLOAT32">4234.1231
+        </total_mevents>
+        <comment NAPItype="NX_CHAR[11]">UNSPECIFIED</comment>
+        <field_label NAPItype="NX_CHAR[11]">UNSPECIFIED</field_label>
+        <instrument_geometry NAPItype="NX_CHAR[11]">UNSPECIFIED</instrument_geometry>
+        <script_name NAPItype="NX_CHAR[2]">1
+        </script_name>
+        <sample_name NAPItype="NX_CHAR[2]">1
+        </sample_name>
+        <sample_orientation NAPItype="NX_CHAR[2]">2
+        </sample_orientation>
+        <temperature_label NAPItype="NX_CHAR[11]">UNSPECIFIED</temperature_label>
+        <npratio_average NAPItype="NX_FLOAT32">31.0000
+        </npratio_average>
+        <isis_cycle NAPItype="NX_CHAR[4]">20_1</isis_cycle>
+        <seci_config NAPItype="NX_CHAR[17]">Based cyberman</seci_config>
+        <event_mode NAPItype="NX_FLOAT64">0.2300000
+        </event_mode>
+        <IXselog name="selog">
+            <IXseblock name="0
+">
+                <current_value NAPItype="NX_CHAR[3]">lol</current_value>
+                <setpoint_value NAPItype="NX_CHAR[3]">wtf</setpoint_value>
+                <average_value NAPItype="NX_CHAR[3]">m8</average_value>
+            </IXseblock>
+        </IXselog>
+    </NXentry>
+    <NXentry name="ENGINX00299085">
+        <title NAPItype="NX_CHAR[15]">Hello world</title>
+        <simulation_mode NAPItype="NX_CHAR[2]">NO</simulation_mode>
+        <user_name NAPItype="NX_CHAR[9]">kdslfs</user_name>
+        <local_contact NAPItype="NX_CHAR[11]">UNSPECIFIED</local_contact>
+        <user_institute NAPItype="NX_CHAR[11]">UNSPECIFIED</user_institute>
+        <experiment_identifier NAPItype="NX_CHAR[7]">21231</experiment_identifier>
+        <instrument_name NAPItype="NX_CHAR[6]">ENGINX</instrument_name>
+        <run_number NAPItype="NX_INT32">31231
+        </run_number>
+        <sample_id NAPItype="NX_CHAR[2]">321
+        </sample_id>
+        <measurement_first_run NAPItype="NX_INT32">31231
+        </measurement_first_run>
+        <measurement_id NAPItype="NX_CHAR[2]">31231
+        </measurement_id>
+        <measurement_label NAPItype="NX_CHAR[11]">UNSPECIFIED</measurement_label>
+        <measurement_type NAPItype="NX_CHAR[2]">0
+        </measurement_type>
+        <measurement_subid NAPItype="NX_CHAR[2]">0
+        </measurement_subid>
+        <start_time NAPItype="NX_CHAR[19]">2020-11-10T14:14:06</start_time>
+        <end_time NAPItype="NX_CHAR[19]">2020-11-10T14:14:12</end_time>
+        <duration NAPItype="NX_INT64">32131
+        </duration>
+        <proton_charge NAPItype="NX_FLOAT32">0.170923
+        </proton_charge>
+        <raw_frames NAPItype="NX_UINT32">231231
+        </raw_frames>
+        <good_frames NAPItype="NX_UINT32">31231
+        </good_frames>
+        <number_periods NAPItype="NX_INT32">3213
+        </number_periods>
+        <number_spectra NAPItype="NX_INT32">543
+        </number_spectra>
+        <number_detectors NAPItype="NX_INT32">523
+        </number_detectors>
+        <number_time_regimes NAPItype="NX_INT32">2
+        </number_time_regimes>
+        <frame_sync NAPItype="NX_CHAR[3]">Sok</frame_sync>
+        <IXtime_regime name="time_regime_1">
+            <number_time_channels NAPItype="NX_INT32">342342
+            </number_time_channels>
+            <time_channel_min NAPItype="NX_FLOAT32">432000.0000
+            </time_channel_min>
+            <time_channel_max NAPItype="NX_FLOAT32">43299.0000
+            </time_channel_max>
+        </IXtime_regime>
+        <IXtime_regime name="time_regime_2">
+            <number_time_channels NAPItype="NX_INT32">423420
+            </number_time_channels>
+            <time_channel_min NAPItype="NX_FLOAT32">6043200.0000
+            </time_channel_min>
+            <time_channel_max NAPItype="NX_FLOAT32">4604300.0000
+            </time_channel_max>
+        </IXtime_regime>
+        <icp_version NAPItype="NX_CHAR[79]">332sdasdasd</icp_version>
+        <detector_table_file NAPItype="NX_CHAR[97]">dsada</detector_table_file>
+        <spectra_table_file NAPItype="NX_CHAR[91]">sdada</spectra_table_file>
+        <wiring_table_file NAPItype="NX_CHAR[83]">sdada</wiring_table_file>
+        <monitor_spectrum NAPItype="NX_INT32">23423
+        </monitor_spectrum>
+        <monitor_sum NAPItype="NX_UINT32">4232
+        </monitor_sum>
+        <total_mevents NAPItype="NX_FLOAT32">234.1231
+        </total_mevents>
+        <comment NAPItype="NX_CHAR[11]">UNSPECIFIED</comment>
+        <field_label NAPItype="NX_CHAR[11]">UNSPECIFIED</field_label>
+        <instrument_geometry NAPItype="NX_CHAR[11]">UNSPECIFIED</instrument_geometry>
+        <script_name NAPItype="NX_CHAR[2]">0
+        </script_name>
+        <sample_name NAPItype="NX_CHAR[2]">0
+        </sample_name>
+        <sample_orientation NAPItype="NX_CHAR[2]">0
+        </sample_orientation>
+        <temperature_label NAPItype="NX_CHAR[11]">UNSPECIFIED</temperature_label>
+        <npratio_average NAPItype="NX_FLOAT32">3.1415926
+        </npratio_average>
+        <isis_cycle NAPItype="NX_CHAR[4]">20_2</isis_cycle>
+        <seci_config NAPItype="NX_CHAR[17]">based cyberman</seci_config>
+        <event_mode NAPItype="NX_FLOAT64">323100000
+        </event_mode>
+        <IXselog name="selog">
+            <IXseblock name="0
+">
+                <current_value NAPItype="NX_CHAR[3]">kjl</current_value>
+                <setpoint_value NAPItype="NX_CHAR[3]">Nadsa</setpoint_value>
+                <average_value NAPItype="NX_CHAR[3]">Nasda</average_value>
+            </IXseblock>
+        </IXselog>
+    </NXentry>
+</NXroot>


### PR DESCRIPTION
Closes #509.

## Description

- Add a small Valkey cache helper for JSON get/set operations.
- Cache the EnginX journal run-to-cycle map in Valkey, while keeping the existing in-process `lru_cache`.
- Fall back to reading journal XML files if Valkey is unavailable or misses.
- Avoid caching an empty map when the journal directory is unavailable.
- Add tests for the cache helper and EnginX cache hit/miss behavior.

## Testing

#### Install/update local deps
```bash
.\.venv\Scripts\python.exe -m pip install -e ".[test]"`
```

### Run Valkey locally
```bash
docker run --rm -p 6379:6379 valkey/valkey:latest
$env:VALKEY_URL = "redis://localhost:6379/0"
$env:ENGINX_MAP_CACHE_TTL_SECONDS = "86400"
```